### PR TITLE
GitHub Collaboration

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,11 +1,29 @@
-## Contributing
+# Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to
 agree to a Contributor License Agreement (CLA) declaring that you have the right to,
 and actually do, grant us the rights to use your contribution. For details, visit
-https://cla.microsoft.com.
+<https://cla.microsoft.com>.
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need
 to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 
 Note that we only accept pull requests from forks so please fork this repository before making any changes. You should contribute your changes on a branch on that fork and create a pull request on the [microsoft/ccf_app_template repository](https://github.com/microsoft/ccf_app_template/compare) from there.
+
+## Recommended working model
+
+We have multiple teams working with us and the following is a suggested model for how to manage your CCF project.
+
+### 1 . Create a GitHub Project
+
+Follow the GitHub guide to create a new project within your organisation [https://docs.github.com/en/issues/planning-and-tracking-with-projects/creating-projects/creating-a-project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/creating-projects/creating-a-project). This is YOUR project and does not relate to the cadence or lifecycle of the CCF project. You may add DRAFT items to this project that are outside of the CCF project. It is only when you create them as Issue's in teh ccf-app-samples repository that we have visibility of them.
+
+### 2. Configure your board
+
+Within your project, we recommend to have the following columns / states.
+
+- Triage - this is where all new items are added.
+- Backlog - these are items that you have committed to. It is important that within this column you ASSIGN the item to someone in your team before you allocate it to our board. After you assign someone to work on this item, you can then "Convert to issue" - you should only convert to issue when you have assigned someone from your team.
+- In Progess - this state means that someone from your team is actively working on it and it is an Issue within the ccf-app-samples repository.
+- PR - at this stage you are waiting for one of the maintainers of the ccf-app-samples project to approve your work
+- Done - you work is complete. Profit!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,14 +16,14 @@ We have multiple teams working with us and the following is a suggested model fo
 
 ### 1 . Create a GitHub Project
 
-Follow the GitHub guide to create a new project within your organisation [https://docs.github.com/en/issues/planning-and-tracking-with-projects/creating-projects/creating-a-project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/creating-projects/creating-a-project). This is YOUR project and does not relate to the cadence or lifecycle of the CCF project. You may add DRAFT items to this project that are outside of the CCF project. It is only when you create them as Issue's in teh ccf-app-samples repository that we have visibility of them.
+Follow the GitHub guide to create a new project within your organisation [https://docs.github.com/en/issues/planning-and-tracking-with-projects/creating-projects/creating-a-project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/creating-projects/creating-a-project). This is YOUR project and does not relate to the cadence or lifecycle of the CCF project. You may add DRAFT items to this project that are outside of the CCF project. It is only when you create them as Issue's in the ccf-app-samples repository that we have visibility of them.
 
 ### 2. Configure your board
 
 Within your project, we recommend to have the following columns / states.
 
 - Triage - this is where all new items are added.
-- Backlog - these are items that you have committed to. It is important that within this column you ASSIGN the item to someone in your team before you allocate it to our board. After you assign someone to work on this item, you can then "Convert to issue" - you should only convert to issue when you have assigned someone from your team.
+- Backlog - these are items that you have committed to. It is important that within this column you ASSIGN the item to someone in your team before you allocate it to our board. You will not be able to assign people to the item after it is in our repository. After you assign someone to work on this item, you can then "Convert to issue" - you should only convert to issue when you have assigned someone from your team.
 - In Progess - this state means that someone from your team is actively working on it and it is an Issue within the ccf-app-samples repository.
 - PR - at this stage you are waiting for one of the maintainers of the ccf-app-samples project to approve your work
 - Done - you work is complete. Profit!


### PR DESCRIPTION
This PR outlines how you can create your own GitHub board and allocate items to the OSS project and give our maintainers an early warning of what you are working on.

This means that we can allocate one of our team to your Pull Request earlier and reduce your feedback loop.