### PR TITLE
Add GET_STARTED.MD doc to get started application development using CCF

### DIFF
--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -77,16 +77,15 @@ There are several approaches to test your application
   - Support both ccf network types [virtual - enclave (TEE hardware)]
   - Governance steps required to deploy your app, initialize, and start the network
 
-- [Linux Machine](#testing-using-linux-machine)
+- [Azure Virtual Machine (Linux)](#testing-using-azure-virtual-machine)
 
   - Support both ccf network types [virtual - enclave (TEE hardware)]
   - Governance steps required to deploy your app, initialize, and start the network
 
-- [Azure Managed CCF Service](#testing-using-azure-managed-ccf-serivce-mccf)
+- [Azure Managed CCF](#testing-using-azure-managed-ccf)
 
-  - Using Azure MCCF service, will Create [a Managed CCF network](https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986) which is (initialized, contains an active member, and In Open State)
   - Support only a ccf network in enclave mode (TEE hardware)
-  - No governance steps required to start up your network, but you need to use governance to propose an application
+  - No governance steps required to start up your network, but you need to use governance to propose your application
 
 #### Testing: Using Sandbox.sh
 
@@ -149,9 +148,11 @@ Now, a network is started with one node and one member, you need to execute the 
 
 To start or join new node you need some configs, The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
 
-#### Testing: Using Linux Machine
+#### Testing: Using Azure Virtual Machine
 
-To Start a test CCF network on a VM, it requires [CCF to be intalled](https://microsoft.github.io/CCF/main/build_apps/install_bin.html)
+To Start a test CCF network on a VM, it requires [CCF to be intalled](https://microsoft.github.io/CCF/main/build_apps/install_bin.html).
+
+To create a ready CCF VM please check [Creating a Virtual Machine in Azure to run CCF](https://github.com/microsoft/CCF/blob/main/getting_started/azure_vm/README.md) 
 
 Start the CCF network using the cchost in enclave mode
 
@@ -181,12 +182,12 @@ Now, a network is started with one node and one member, you need to execute the 
 
 To start or join new node you need some configs, The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
 
-#### Testing: Using Azure Managed CCF Serivce ([MCCF](https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986))
+#### Testing: Using [Azure Managed CCF](https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986)
 
-To test you application using MCCF, you can create Azure Managed CCF Serivce on your subscription, the service will create a CCF network which is (initialized, Active member, and In Open State)
+To test you application using Managed CCF, you can create Azure Managed CCF serivce on your subscription, the service will create a ready CCF network
 
-- First, create the network's first member certificate, please check [Certificates generation](https://microsoft.github.io/CCF/release/3.x/governance/adding_member.htmlhttps://microsoft.github.io/CCF/release/3.x/governance/adding_member.html)
-- Create a new Azure Managed CCF Serivce (first member certificate required as input)
+- First, create the network's initial member certificate, please check [Certificates generation](https://microsoft.github.io/CCF/release/3.x/governance/adding_member.html)
+- Create a new Azure Managed CCF serivce (the initial member certificate required as input)
 - Build the application and [create a deployment proposal](#build-application)
 - Deploy the application proposal, [using governance calls](#network-governance)
 - Create and submit [an add users proposal](#new-user-proposal)
@@ -198,6 +199,8 @@ To check samples on how to test your application endpoints, please check these r
 - [Banking Application](https://github.com/microsoft/ccf-app-samples/tree/main/banking-app)
 - [Template Application](https://github.com/microsoft/ccf-app-template)
 
+
+---
 ## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=40px></img> C++ Applications
 
 CCF apps can also be written in C++. This offers better performance than JavaScript apps but requires a compilation step and a restart of the CCF node for deployment. please check [ccf-app-template](https://github.com/microsoft/ccf-app-template) repository.
@@ -222,7 +225,7 @@ Members vote to accept or reject the proposal
 ```
 
 ```
-Note: Members and users, certificates and keys, must be generated before starting a CCF network, please check [Certificates generation](https://microsoft.github.io/CCF/release/3.x/governance/adding_member.htmlhttps://microsoft.github.io/CCF/release/3.x/governance/adding_member.html).
+Note: The initial member's certificate and private key, must be generated before starting a CCF network, please check [Certificates generation](https://microsoft.github.io/CCF/release/3.x/governance/adding_member.html).
 ```
 
 ### Network Governance: Activating network members
@@ -247,7 +250,7 @@ cat request.json
       "name": "set_member",
       "args": {
         "cert": "member_cert",
-        "encryption_pub_key": "member_encryption_pub_key"
+        "encryption_pub_key": <member_encryption_pub_key>
       }
     }
   ]
@@ -269,7 +272,7 @@ First, the identities of trusted users should be generated,see [Generating Membe
     {
       "name": "set_user",
       "args": {
-        "cert": "user_cert"
+        "cert": <user_cert>
       }
     }
   ]
@@ -289,8 +292,8 @@ The native format for JavaScript applications in CCF is a [JavaScript applicatio
       "name": "set_js_app",
       "args": {
         "bundle": {
-          "metadata": { "endpoints": {} },
-          "modules": []
+          "metadata": { "endpoints": {<endpoints>} },
+          "modules": [<modules>]
         }
       }
     }
@@ -314,7 +317,7 @@ It is only then that users are able to execute transactions on the deployed appl
     {
       "name": "transition_service_to_open",
       "args": {
-        "next_service_identity": "service_cert"
+        "next_service_identity": <service_cert>
       }
     }
   ]

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -385,6 +385,3 @@ echo "Verify the installation"
 /opt/ccf/bin/cchost --version
 ```
 
-# Code Tour
-
-In VSCode, a [code tour](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour) of the C++ app can be started with: Ctrl + P, `> CodeTour: Start Tour`

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -152,7 +152,7 @@ To start or join new node you need some configs, The configuration for each CCF 
 
 To Start a test CCF network on a VM, it requires [CCF to be intalled](https://microsoft.github.io/CCF/main/build_apps/install_bin.html).
 
-To create a ready CCF VM please check [Creating a Virtual Machine in Azure to run CCF](https://github.com/microsoft/CCF/blob/main/getting_started/azure_vm/README.md) 
+To create a ready CCF VM please check [Creating a Virtual Machine in Azure to run CCF](https://github.com/microsoft/CCF/blob/main/getting_started/azure_vm/README.md)
 
 Start the CCF network using the cchost in enclave mode
 
@@ -199,8 +199,8 @@ To check samples on how to test your application endpoints, please check these r
 - [Banking Application](https://github.com/microsoft/ccf-app-samples/tree/main/banking-app)
 - [Template Application](https://github.com/microsoft/ccf-app-template)
 
-
 ---
+
 ## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=40px></img> C++ Applications
 
 CCF apps can also be written in C++. This offers better performance than JavaScript apps but requires a compilation step and a restart of the CCF node for deployment. please check [ccf-app-template](https://github.com/microsoft/ccf-app-template) repository.

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -224,6 +224,7 @@ Or, for an SGX-enabled application (unavailable in development container): `$ /o
 ### Run C++ app: Using Docker
 
 It is possible to build a runtime image of the C++ application via docker:
+
 ```bash
 $ docker build -t ccf-app-template:cpp-enclave -f docker/ccf_app_cpp.enclave .
 $ docker run --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx ccf-app-template:cpp-enclave

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -44,15 +44,17 @@ To test a ccf application you need go through the following steps:
 
 ### Build Application
 
-The application building prerequisites [[CCF](#ccf-install), NodeJS and NPM] installed, all will be preinstalled if you are using devcontainer enviroment,
+The application building prerequisites [[CCF](#ccf-install), NodeJS and NPM] must be installed,
+all will be preinstalled if you are using devcontainer environment,
 otherwise you need to manually install.
 
 In the checkout of this repository:
 
 ```bash
-cd js
+cd banking-app
 npm install
-npm run build
+# build and generate the application bundle and deployment proposal
+make build
 ls
 cd ..
 
@@ -65,25 +67,32 @@ cd ..
 
 There are servral ways and tools which helping to test your application
 
-- Sandbox.sh
+- [Sandbox.sh](#testing-using-sandboxsh)
 
-  - build an initialized a ccf network and deploy your app top it
+  - Build an initialized CCF network and deploy your app on top of it
   - Support both ccf network types [virtual - release (TEE hardware)]
   - No governance steps required
 
-- Docker container
+- [Docker container](#testing-using-docker-containers)
 
   - Support both ccf network types [virtual - release (TEE hardware)]
   - Governance steps required to deploy your app, initialize, and start the network
 
-- Linux Machine
+- [Linux Machine](#testing-using-linux-machine)
+
   - Support both ccf network types [virtual - release (TEE hardware)]
   - Governance steps required to deploy your app, initialize, and start the network
+
+- [Azure Managed CCF Service](#testing-using-azure-managed-ccf-serivce-mccf)
+
+  - Using Azure MCCF service, will Create [a Managed CCF network](https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986) which is (initialized, contains an active member, and In Open State)
+  - Support only a ccf network in release mode (TEE hardware)
+  - No governance steps required to start up your network, but you need to deploy your app proposal
 
 #### Testing: Using Sandbox.sh
 
-By runing sandbox.sh script, it is automatically starting a CCF network and deploy your application on it, the app is up and ready to receive calls,
-all the governance work is done for you.
+By running sandbox.sh script, it is automatically starts a CCF network and deploys your application on it.
+The app is up and ready to receive calls and all the governance work is done for you.
 
 Start in a CCF Network in Release mode
 
@@ -105,9 +114,9 @@ Start in a CCF Network in Virtual mode (the default mode for testing)
 
 #### Testing: Using docker containers
 
-Build and run one of these docker files ["ccf_app_js.virtual" or "ccf_app_js.enclave"] to start a CCF network with one node and one member
-after that you need to execute governance steps to deploy the application and open the network for users to begin access the app endpoints.
-all the governance steps is done manually using [proposal submit and vote process](https://microsoft.github.io/CCF/main/governance/proposals.html).
+Build and run one of these docker files ["ccf_app_js.virtual" or "ccf_app_js.enclave"] to start a CCF network with one node and one member.
+After that, you need to execute governance steps to deploy the application and open the network for users to begin access the app endpoints.
+All the governance steps need to be done manually using [proposal submit and vote process](https://microsoft.github.io/CCF/main/governance/proposals.html).
 
 ##### Build and run docker container to start a CCF network
 
@@ -129,18 +138,17 @@ Start in a CCF Network in Virtual mode, based on virtual config file: "./config/
  # CCF Network initialization needed before the interaction with the service
 ```
 
+Now, a network is started with one node and one member, you need to execute the following governance steps to initialize the network, [check Network governance section](#network-governance)
+
+- Activate the network existing member (to start a network governance)
+- Build the application and [create a deployment proposal](#build-application)
+- Deploy the application proposal, [using governance calls](#network-governance)
+- Optionally Create and submit [an add users proposal](#new-user-proposal)
+- Open the network for users ([using proposal](#open-network-proposal))
+
 ##### CCF Node Configuration file
 
-The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
-
-##### CCF network initialization
-
-After the container run, a network is started with one (node - member), you need to execute the following governance steps to initialize the network, [check Network governance section](#network-governance)
-
-- Activate the network members (to begin network governance)
-- Add users (using proposal)
-- Deploy the application (using proposal)
-- Open the network for users (using proposal)
+To start or join new node you need some configs, The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
 
 #### Testing: Using Linux Machine
 
@@ -150,26 +158,39 @@ Start the CCF network using the cchost in release mode
 
 ```bash
  /opt/ccf/bin/cchost --config ./config/cchost_config_enclave_js.json
+ ...
+ # CCF Network initialization needed before the interaction with the service
 ```
 
 Or virtual mode
 
 ```bash
 /opt/ccf/bin/cchost --config ./config/cchost_config_virtual_js.json
+...
+ # CCF Network initialization needed before the interaction with the service
 ```
+
+Now, a network is started with one node and one member, you need to execute the following governance steps to initialize the network, [check Network governance section](#network-governance)
+
+- Activate the network existing member (to start a network governance)
+- Build the application and [create a deployment proposal](#build-application)
+- Deploy the application proposal, [using governance calls](#network-governance)
+- Create and submit [an add users proposal](#new-user-proposal)
+- Open the network for users ([using proposal](#open-network-proposal))
 
 ##### CCF Node Configuration file
 
-The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
+To start or join new node you need some configs, The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
 
-##### CCF network initialization
+#### Testing: Using Azure Managed CCF Serivce ([MCCF](https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986))
 
-Network is started with one (node - member), you need to execute the following governance steps to initialize the network,, [check Network governance section](#network-governance)
+To test you application using MCCF, you can create Azure Managed CCF Serivce on your subscription, the service will create a CCF network which is (initialized, Active member, and In Open State)
 
-- Activate the network members (to start a network governance)
-- Add users (using proposal)
-- Deploy the application (using proposal)
-- Open the network for users (using proposal)
+- First, create the network's first member certificate, please check [Certificates generation](https://microsoft.github.io/CCF/release/3.x/governance/adding_member.htmlhttps://microsoft.github.io/CCF/release/3.x/governance/adding_member.html)
+- Create a new Azure Managed CCF Serivce (first member certificate required as input)
+- Build the application and [create a deployment proposal](#build-application)
+- Deploy the application proposal, [using governance calls](#network-governance)
+- Create and submit [an add users proposal](#new-user-proposal)
 
 ### Testing: Application Endpoints
 
@@ -217,8 +238,6 @@ curl https://ccf_service_url/app/balance/$account_type1 -X GET --cacert service_
 CCF apps can also be written in C++. This offers better performance than JavaScript apps but requires a compilation step and a restart of the CCF node for deployment.
 
 The C++ sample app is located in the [`cpp/`](cpp/) directory.
-
-Also check out the [code tour](#code-tour) to get an overview of the C++ app.
 
 ### Build C++ app
 
@@ -288,6 +307,10 @@ Members vote to accept or reject the proposal
 /opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/proposals/$proposal0_id/ballots" --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @vote_accept.json -H "content-type: application/json" | jq
 ```
 
+```
+Note: Members and users, certificates and keys, must be generated before starting a CCF network, please check [Certificates generation](https://microsoft.github.io/CCF/release/3.x/governance/adding_member.htmlhttps://microsoft.github.io/CCF/release/3.x/governance/adding_member.html).
+```
+
 ### Network Governance: Activating network members
 
 By default the CCF network needs at least one member to be started, after the network is started this member must be activated.
@@ -319,7 +342,7 @@ cat request.json
 
 ### Network Governance: Adding users
 
-Users are directly interact with the application running in CCF. Their public identity should be voted in by members before they are allowed to issue requests.
+Users directly interact with the application running in CCF. Their public identities should be voted in by members before they are allowed to issue requests
 
 Once a CCF network is successfully started and an acceptable number of nodes have joined, members should vote to open the network to Users.
 First, the identities of trusted users should be generated,see [Generating Member Keys and Certificates](https://microsoft.github.io/CCF/main/governance/adding_member.html#generating-member-keys-and-certificates) and [Adding Users docs](https://microsoft.github.io/CCF/main/governance/open_network.html)

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -25,14 +25,14 @@ Applications can be written in
 
 - VS Code Dev Container [![Open in VSCode](https://img.shields.io/static/v1?label=Open+in&message=VSCode&logo=visualstudiocode&color=007ACC&logoColor=007ACC&labelColor=2C2C32)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/ccf-app-samples)
 - Github codespace: [![Github codespace](https://img.shields.io/static/v1?label=Open+in&message=GitHub+codespace&logo=github&color=2F363D&logoColor=white&labelColor=2C2C32)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=496290904&machine=basicLinux32gb&devcontainer_path=.devcontainer.json&location=WestEurope)
-- Linux Machine ([Create a VM](https://learn.microsoft.com/en-us/azure/confidential-computing/quick-create-portal) and [Install ccf](https://microsoft.github.io/CCF/main/build_apps/install_bin.html))
+- Virtual Machine ([Creating a Virtual Machine in Azure to run CCF](https://github.com/microsoft/CCF/blob/main/getting_started/azure_vm/README.md))
 
 ## <img src="https://user-images.githubusercontent.com/42961061/191275583-88e00f94-73aa-4d66-9786-047987eb9fa9.png" height=40px /> (JavaScript/Typescript) Applications
 
-To test a ccf application you need go through the following steps:
+CCF apps can also be written in JavaScript or Typescript, To test a ccf application you need go through the following steps:
 
 - Start a CCF Network with at least one node
-- Initialize the CCF network with at least one (active member - user), this is done through [Network Governance Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html).
+- Initialize the CCF network with at least one (active member - user), this can be done through [Network Governance Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html).
 - Create an application [deployment proposal](https://microsoft.github.io/CCF/main/build_apps/js_app_bundle.html)
 - Submit the app deployment proposal to the network and all members accept it through voting. This is a part of [Network Governance](https://microsoft.github.io/CCF/main/governance/proposals.html).
 - Open the CCF network for users

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -1,10 +1,6 @@
 # Get Started: Application Development using CCF
 
-## Overview
-
-Get started repository for building CCF applications using (JavaScript, TypeScript and C++).
-
-## Quick start
+# Overview
 
 What is CCF: The [Confidential Consortium Framework (CCF)](https://ccf.dev/) is an open-source framework for building a new category of secure, highly available,
 and performant applications that focus on multi-party compute and data.
@@ -31,7 +27,7 @@ Applications can be written in
 - Github codespace: [![Github codespace](https://img.shields.io/static/v1?label=Open+in&message=GitHub+codespace&logo=github&color=2F363D&logoColor=white&labelColor=2C2C32)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=496290904&machine=basicLinux32gb&devcontainer_path=.devcontainer.json&location=WestEurope)
 - Linux Machine ([Create a VM](https://learn.microsoft.com/en-us/azure/confidential-computing/quick-create-portal) and [Install ccf](https://microsoft.github.io/CCF/main/build_apps/install_bin.html))
 
-## <img src="https://user-images.githubusercontent.com/42961061/191275583-88e00f94-73aa-4d66-9786-047987eb9fa9.png" height=50px> </img> (JS/Typescript) Applications
+## <img src="https://user-images.githubusercontent.com/42961061/191275583-88e00f94-73aa-4d66-9786-047987eb9fa9.png" height=40px /> (JavaScript/Typescript) Applications
 
 To test a ccf application you need go through the following steps:
 
@@ -44,11 +40,9 @@ To test a ccf application you need go through the following steps:
 
 ### Build Application
 
-The application building prerequisites [[CCF](#ccf-install), NodeJS and NPM] must be installed,
-all will be preinstalled if you are using devcontainer environment,
-otherwise you need to manually install.
+The application building prerequisites [[CCF](#ccf-install), NodeJS and NPM] must be installed,all will be preinstalled if you are using devcontainer environment, otherwise you need to install them manually .
 
-In the checkout of this repository:
+In the checkout of [ccf-app-samples](https://github.com/microsoft/ccf-app-samples) repository:
 
 ```bash
 # carried out on the dev-container start up
@@ -59,8 +53,6 @@ make build
 
 # a dist folder is created with app bundle and deployment proposal.
 ```
-
----
 
 ### Testing your Application
 
@@ -87,7 +79,7 @@ There are several approaches to test your application
   - Support only a ccf network in enclave mode (TEE hardware)
   - No governance steps required to start up your network, but you need to use governance to propose your application
 
-#### Testing: Using Sandbox.sh
+### Testing: Using Sandbox.sh
 
 By running sandbox.sh script, it is automatically starts a CCF network and deploys your application on it.
 The app is up and ready to receive calls and all the governance work is done for you.
@@ -110,13 +102,13 @@ Start in a CCF Network in Virtual mode (the default mode for testing)
 # It is then possible to interact with the service
 ```
 
-#### Testing: Using docker containers
+### Testing: Using docker containers
 
 Build and run one of these docker files ["ccf_app_js.virtual" or "ccf_app_js.enclave"] to start a CCF network with one node and one member.
 After that, you need to execute governance steps to deploy the application and open the network for users to begin access the app endpoints.
 All the governance steps need to be done manually using [proposal submit and vote process](https://microsoft.github.io/CCF/main/governance/proposals.html).
 
-##### Build and run docker container to start a CCF network
+#### Build and run docker container to start a CCF network
 
 Start in a CCF Network in Enclave mode, via docker container based on config file "./config/cchost_config_enclave_js.json"
 
@@ -144,11 +136,11 @@ Now, a network is started with one node and one member, you need to execute the 
 - Optionally Create and submit [an add users proposal](#new-user-proposal)
 - Open the network for users ([using proposal](#open-network-proposal))
 
-##### CCF Node Configuration file
+#### CCF Node Configuration file
 
 To start or join new node you need some configs, The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
 
-#### Testing: Using Azure Virtual Machine
+### Testing: Using Azure Virtual Machine
 
 To Start a test CCF network on a VM, it requires [CCF to be intalled](https://microsoft.github.io/CCF/main/build_apps/install_bin.html).
 
@@ -178,11 +170,11 @@ Now, a network is started with one node and one member, you need to execute the 
 - Create and submit [an add users proposal](#new-user-proposal)
 - Open the network for users ([using proposal](#open-network-proposal))
 
-##### CCF Node Configuration file
+#### CCF Node Configuration file
 
 To start or join new node you need some configs, The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
 
-#### Testing: Using [Azure Managed CCF](https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986)
+### Testing: Using [Azure Managed CCF](https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986)
 
 To test you application using Managed CCF, you can create Azure Managed CCF serivce on your subscription, the service will create a ready CCF network
 
@@ -199,13 +191,54 @@ To check samples on how to test your application endpoints, please check these r
 - [Banking Application](https://github.com/microsoft/ccf-app-samples/tree/main/banking-app)
 - [Template Application](https://github.com/microsoft/ccf-app-template)
 
----
-
-## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=40px></img> C++ Applications
+## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=40px /> C++ Applications
 
 CCF apps can also be written in C++. This offers better performance than JavaScript apps but requires a compilation step and a restart of the CCF node for deployment. please check [ccf-app-template](https://github.com/microsoft/ccf-app-template) repository.
 
-## <img src="https://microsoft.github.io/CCF/release/3.x/_static/ccf.svg" height=40px></img> Network Governance
+The C++ sample app is located in the [`cpp/`](cpp/) directory.
+
+### Build C++ app
+
+In the checkout of [ccf-app-template](https://github.com/microsoft/ccf-app-template) repository:
+
+```bash
+ cd cpp/
+ mkdir build && cd build
+ CC="/opt/oe_lvi/clang-10" CXX="/opt/oe_lvi/clang++-10" cmake -GNinja ..
+ ninja
+ ls
+
+#libccf_app.enclave.so.signed # SGX-enabled application
+#libccf_app.virtual.so # Virtual application (i.e. insecure!)
+```
+
+### Run C++ app: Using Sandbox.sh
+
+```bash
+$ /opt/ccf/bin/sandbox.sh -p ./libccf_app.virtual.so
+[12:00:00.000] Press Ctrl+C to shutdown the network
+```
+
+Or, for an SGX-enabled application (unavailable in development container): `$ /opt/ccf/bin/sandbox.sh -p ./libccf_app.enclave.so.signed -e release`
+
+### Run C++ app: Using Docker
+
+It is possible to build a runtime image of the C++ application via docker:
+```bash
+$ docker build -t ccf-app-template:cpp-enclave -f docker/ccf_app_cpp.enclave .
+$ docker run --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx ccf-app-template:cpp-enclave
+
+# Or, for the non-SGX (a.k.a. virtual) variant:
+
+$ docker build -t ccf-app-template:cpp-virtual -f docker/ccf_app_cpp.virtual .
+$ docker run ccf-app-template:virtual
+...
+2022-01-01T12:00:00.000000Z -0.000 0   [info ] ../src/node/node_state.h:1790        | Network TLS connections now accepted
+...
+# CCF Network initialization needed before the interaction with the service
+```
+
+## <img src="https://microsoft.github.io/CCF/release/3.x/_static/ccf.svg" height=40px /> Network Governance
 
 a Consortium of trusted Members [governs the CCF network](https://microsoft.github.io/CCF/main/governance/index.html). members can submit proposals to CCF and these proposals are accepted based on the rules defined in the [Constitution](https://microsoft.github.io/CCF/main/governance/constitution.html).
 Governance changes are submitted to a [network as Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html), and put to a vote from members.
@@ -303,8 +336,7 @@ The native format for JavaScript applications in CCF is a [JavaScript applicatio
 
 ### Network Governance: Open network for users
 
-Once users are added to the opening network, members should create a proposal to open the network,
-Other members are then able to vote for the proposal using the returned proposal id.
+Once users are added to the network, members should create a [proposal to open the network](https://microsoft.github.io/CCF/main/governance/open_network.html), Other members are then able to vote for the proposal using the returned proposal id.
 
 Once the proposal has received enough votes under the rules of the Constitution (ie. ballots which evaluate to true), the network is opened to users.
 It is only then that users are able to execute transactions on the deployed application.
@@ -323,8 +355,6 @@ It is only then that users are able to execute transactions on the deployed appl
   ]
 }
 ```
-
----
 
 ## Development Dependencies Installation
 

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -1,0 +1,390 @@
+# Get Started: Application Development using CCF
+
+## Overview
+Get started repository for building CCF applications using (JavaScript, TypeScript and C++).
+
+## Quick start
+What is CCF: The [Confidential Consortium Framework (CCF)](https://ccf.dev/) is an open-source framework for building a new category of secure, highly available,
+and performant applications that focus on multi-party compute and data.
+
+- Read the [CCF overview](https://microsoft.github.io/CCF/main/overview/index.html) and get familiar with [CCF's core concepts](https://microsoft.github.io/CCF/main/overview/what_is_ccf.html) and [Azure confidential computing](https://learn.microsoft.com/en-us/azure/confidential-computing/)
+- [Build new CCF applications](https://microsoft.github.io/CCF/main/build_apps/index.html) in TypeScript/JavaScript or C++
+- CCF [Modules API reference](https://microsoft.github.io/CCF/main/js/ccf-app/modules.html)
+- CCF application get started repos
+    -  [CCF application template](https://github.com/microsoft/ccf-app-template)
+    -  [CCF application samples](https://github.com/microsoft/ccf-app-samples)
+
+## Supported Programing Languages
+Applications can be written in
+- TypeScript
+- JavaScript
+- C++
+- More languages support upcoming on 2023
+
+## Development environment
+- Development container and VSCode [![Open in VSCode](https://img.shields.io/static/v1?label=Open+in&message=VSCode&logo=visualstudiocode&color=007ACC&logoColor=007ACC&labelColor=2C2C32)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/ccf-app-samples) 
+- Github codespace: [![Github codespace](https://img.shields.io/static/v1?label=Open+in&message=GitHub+codespace&logo=github&color=2F363D&logoColor=white&labelColor=2C2C32)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=496290904&machine=basicLinux32gb&devcontainer_path=.devcontainer.json&location=WestEurope)
+- Linux Machine ([Create a VM](https://learn.microsoft.com/en-us/azure/confidential-computing/quick-create-portal) and [Install ccf](https://microsoft.github.io/CCF/main/build_apps/install_bin.html))
+
+## <img src="https://user-images.githubusercontent.com/42961061/191275583-88e00f94-73aa-4d66-9786-047987eb9fa9.png" height=50px> </img>  (JS/Typescript) Applications
+To test a ccf application you need go through the following steps:
+- Start a CCF Network with at least one node
+- Initialize the CCF network with at least one (active member - user), this is done through [Network Governance Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html).
+- Create an application [deployment proposal](https://microsoft.github.io/CCF/main/build_apps/js_app_bundle.html)
+- Submit the app deployment proposal to the network and all members accept it through voting, This is a part of [Network Governance](https://microsoft.github.io/CCF/main/governance/proposals.html).
+- Open the CCF network for users
+- Start to test your application endpoints
+
+### Build Application
+
+The application building prerequisites [[CCF](#ccf-install), NodeJS and NPM] installed, all will be preinstalled if you are using devcontainer enviroment,
+otherwise you need to manually install.
+
+In the checkout of this repository:
+
+```bash
+cd js
+npm install
+npm run build
+ls
+cd ..
+
+# a dist folder is created with app bundle.
+```
+---
+### Testing your Application
+
+There are servral ways and tools which helping to test your application
+- Sandbox.sh 
+    - build an initialized a ccf network and deploy your app top it
+    - Support both ccf network types [virtual - release (TEE hardware)]
+    - No governance steps required
+
+- Docker container 
+    - Support both ccf network types [virtual - release (TEE hardware)]
+    - Governance steps required to deploy your app, initialize, and start the network
+
+- Linux Machine
+    - Support both ccf network types [virtual - release (TEE hardware)]
+    - Governance steps required to deploy your app, initialize, and start the network
+
+#### Testing: Using Sandbox.sh
+
+By runing sandbox.sh script, it is automatically starting a CCF network and deploy your application on it, the app is up and ready to receive calls,
+all the governance work is done for you.
+
+Start in a CCF Network in Release mode
+```bash
+/opt/ccf/bin/sandbox.sh --js-app-bundle ./js/dist/  --enclave-type release -p /opt/ccf/lib/libjs.enclave.so.signed
+...
+[12:00:00.000] Press Ctrl+C to shutdown the network
+# It is then possible to interact with the service
+```
+
+Start in a CCF Network in Virtual mode (the default mode for testing)
+```bash
+/opt/ccf/bin/sandbox.sh --js-app-bundle ./js/dist/
+...
+[12:00:00.000] Press Ctrl+C to shutdown the network
+# It is then possible to interact with the service
+```
+
+#### Testing: Using docker containers
+
+Build and run one of these docker files ["ccf_app_js.virtual" or "ccf_app_js.enclave"] to start a CCF network with one node and one member
+after that you need to execute governance steps to deploy the application and open the network for users to begin access the app endpoints.
+all the governance steps is done manually using [proposal submit and vote process](https://microsoft.github.io/CCF/main/governance/proposals.html).
+
+##### Build and run docker container to start a CCF network
+
+Start in a CCF Network in Release mode, via docker container based on config file "./config/cchost_config_enclave_js.json"
+
+```bash
+ docker build -t ccf-app-samples:js-enclave -f docker/ccf_app_js.enclave .
+ docker run -d --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx ccf-app-samples:js-enclave
+ ...
+ # CCF Network initialization needed before the interaction with the service
+```
+
+Start in a CCF Network in Virtual mode, based on virtual config file: "./config/cchost_config_virtual_js.json":
+```bash
+ docker build -t ccf-app-samples:js-virtual -f docker/ccf_app_js.virtual .
+ docker run -d ccf-app-samples:js-virtual
+ ...
+ # CCF Network initialization needed before the interaction with the service
+```
+
+##### CCF Node Configuration file
+The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
+
+##### CCF network initialization
+After the container run, a network is started with one (node - member), you need to execute the following governance steps to initialize the network, [check Network governance section](#network-governance)
+- Activate the network members (to begin network governance)
+- Add users (using proposal)
+- Deploy the application (using proposal)
+- Open the network for users (using proposal)
+
+#### Testing: Using Linux Machine
+To Start a test CCF network on a VM, it requires [CCF to be intalled](https://microsoft.github.io/CCF/main/build_apps/install_bin.html)
+
+Start the CCF network using the cchost in release mode
+```bash
+ /opt/ccf/bin/cchost --config ./config/cchost_config_enclave_js.json
+```
+Or virtual mode
+```bash
+/opt/ccf/bin/cchost --config ./config/cchost_config_virtual_js.json
+```
+
+##### CCF Node Configuration file
+The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
+
+##### CCF network initialization
+Network is started with one (node - member), you need to execute the following governance steps to initialize the network,, [check Network governance section](#network-governance)
+- Activate the network members (to start a network governance)
+- Add users (using proposal)
+- Deploy the application (using proposal)
+- Open the network for users (using proposal)
+
+### Testing: Application Endpoints  
+
+Now you can send requests to your endpoints, the following sample requests to log application [(ccf-app-template)](https://github.com/microsoft/ccf-app-template/tree/main/js)
+
+In another terminal:
+
+#### Log application
+```bash
+ # send log message to be saved
+ curl -X POST https://127.0.0.1:8000/app/log?id=1 --cacert ./workspace/sandbox_common/service_cert.pem -H "Content-Type: application/json" --data '{"msg": "hello world"}'
+ # retrieve log message
+ curl https://127.0.0.1:8000/app/log?id=1 --cacert ./workspace/sandbox_common/service_cert.pem
+ # return:> hello world
+```
+
+#### Banking application
+```bash
+echo "Define vars"
+user0_id=$(openssl x509 -in "user0_cert.pem" -noout -fingerprint -sha256 | cut -d "=" -f 2 | sed 's/://g' | awk '{print tolower($0)}')
+user1_id=$(openssl x509 -in "user1_cert.pem" -noout -fingerprint -sha256 | cut -d "=" -f 2 | sed 's/://g' | awk '{print tolower($0)}')
+account_type0='current_account'
+account_type1='savings_account'
+
+echo "create accounts"
+curl https://ccf_service_url/app/account/$user0_id/$account_type0 -X PUT --cacert service_cert.pem --cert member0_cert.pem --key member0_privk.pem
+curl https://ccf_service_url/app/account/$user1_id/$account_type1 -X PUT --cacert service_cert.pem --cert member0_cert.pem --key member0_privk.pem
+
+echo "deposit and display balance for account0"
+curl https://ccf_service_url/app/deposit/$user0_id/$account_type0 -X POST --cacert service_cert.pem --cert member0_cert.pem --key member0_privk.pem -H "Content-Type: application/json" --data-binary '{ "value": 100 }'
+curl https://ccf_service_url/app/balance/$account_type0 -X GET --cacert service_cert.pem --cert user0_cert.pem --key user0_privk.pem
+
+echo "deposit and display balance for account1"
+curl https://ccf_service_url/app/deposit/$user1_id/$account_type1 -X POST --cacert service_cert.pem --cert member0_cert.pem --key member0_privk.pem -H "Content-Type: application/json" --data-binary '{ "value": 2000 }'
+curl https://ccf_service_url/app/balance/$account_type1 -X GET --cacert service_cert.pem --cert user1_cert.pem --key user1_privk.pem
+
+echo "Transfer 40 from user0 to user1"
+transfer_transaction_id=$(curl https://ccf_service_url/app/transfer/$account_type0 -X POST -i --cacert service_cert.pem --cert user0_cert.pem --key user0_privk.pem -H "Content-Type: application/json" --data-binary "{ \"value\": 40, \"user_id_to\": \"$user1_id\", \"account_name_to\": \"$account_type1\" }" | grep -i x-ms-ccf-transaction-id | awk '{print $2}' | sed -e 's/\r//g')
+echo "transaction ID of the transfer: $transfer_transaction_id"
+
+echo "Display receipt"
+curl https://ccf_service_url/app/receipt?transaction_id=$transfer_transaction_id --cacert service_cert.pem --key user0_privk.pem --cert user0_cert.pem
+
+echo "Display balance"
+curl https://ccf_service_url/app/balance/$account_type0 -X GET --cacert service_cert.pem --cert user0_cert.pem --key user0_privk.pem
+curl https://ccf_service_url/app/balance/$account_type1 -X GET --cacert service_cert.pem --cert user1_cert.pem --key user1_privk.pem
+```
+---
+## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=50px></img> C++ Applications 
+
+CCF apps can also be written in C++. This offers better performance than JavaScript apps but requires a compilation step and a restart of the CCF node for deployment.
+
+The C++ sample app is located in the [`cpp/`](cpp/) directory.
+
+Also check out the [code tour](#code-tour) to get an overview of the C++ app.
+
+### Build C++ app
+
+In the checkout of this repository:
+
+```bash
+cd cpp/
+mkdir build && cd build
+CC="/opt/oe_lvi/clang-10" CXX="/opt/oe_lvi/clang++-10" cmake -GNinja ..
+ninja
+ls
+
+#libccf_app.enclave.so.signed # SGX-enabled application
+#libccf_app.virtual.so # Virtual application (i.e. insecure!)
+```
+
+See [docs](https://microsoft.github.io/CCF/main/build_apps) for complete instructions on how to build a CCF app.
+
+### Testing: Using Sandbox.sh
+
+```bash
+/opt/ccf/bin/sandbox.sh -p ./libccf_app.virtual.so
+...
+[12:00:00.000] Press Ctrl+C to shutdown the network
+# It is then possible to interact with the service
+```
+
+Or, for an SGX-enabled application (unavailable in development container): `$ /opt/ccf/bin/sandbox.sh -p ./libccf_app.enclave.so.signed -e release`
+
+### Testing: Using docker containers
+
+It is possible to build a runtime image of the C++ application via docker:
+
+```bash
+docker build -t ccf-app-template:cpp-enclave -f docker/ccf_app_cpp.enclave .
+docker run --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx ccf-app-template:cpp-enclave
+...
+2022-01-01T12:00:00.000000Z -0.000 0   [info ] ../src/node/node_state.h:1790        | Network TLS connections now accepted
+# It is then possible to interact with the service
+```
+
+Or, for the non-SGX (a.k.a. virtual) variant:
+
+```bash
+docker build -t ccf-app-template:cpp-virtual -f docker/ccf_app_cpp.virtual .
+docker run ccf-app-template:virtual
+```
+---
+
+# Network Governance
+a Consortium of trusted Members [governs the CCF network](https://microsoft.github.io/CCF/main/governance/index.html). members can submit proposals to CCF and these proposals are accepted based on the rules defined in the [Constitution](https://microsoft.github.io/CCF/main/governance/constitution.html).
+Governance changes are submitted to a [network as Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html), and put to a vote from members.
+
+Submit a proposal 
+```bash
+proposal0_out=$(/opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/proposals" --cacert service_cert.pem --signing-key member0_privk.pem --signing-cert member0_cert.pem --data-binary @proposal.json -H "content-type: application/json")
+proposal0_id=$( jq -r  '.proposal_id' <<< "${proposal0_out}" )
+```
+
+Members vote to accept or reject the proposal
+```bash
+/opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/proposals/$proposal0_id/ballots" --cacert service_cert.pem --signing-key member0_privk.pem --signing-cert member0_cert.pem --data-binary @vote_accept.json -H "content-type: application/json" | jq
+/opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/proposals/$proposal0_id/ballots" --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @vote_accept.json -H "content-type: application/json" | jq
+```
+ 
+## Network Governance: Activating network members 
+
+By default the CCF network needs at least one member to be started, after the network is started this member must be activated.
+[Adding or activating members](https://microsoft.github.io/CCF/main/governance/adding_member.html)
+
+### Activate member
+```bash
+curl "https://ccf_service_url/gov/ack/update_state_digest" -X POST --cacert service_cert.pem --key member0_privk.pem --cert member0_cert.pem --silent | jq > request.json
+cat request.json
+/opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/ack"  --cacert service_cert.pem --signing-key member0_privk.pem --signing-cert member0_cert.pem --header "Content-Type: application/json" --data-binary @request.json
+```
+
+### New member proposal
+```json
+{
+  "actions": [
+    {
+        "name": "set_member",
+        "args": {
+            "cert": "member_cert",
+            "encryption_pub_key": "member_encryption_pub_key"
+        }
+    }
+  ]
+}
+```
+
+## Network Governance: Adding users 
+Users are directly interact with the application running in CCF. Their public identity should be voted in by members before they are allowed to issue requests.
+
+Once a CCF network is successfully started and an acceptable number of nodes have joined, members should vote to open the network to Users. 
+First, the identities of trusted users should be generated,see [Generating Member Keys and Certificates](https://microsoft.github.io/CCF/main/governance/adding_member.html#generating-member-keys-and-certificates) and [Adding Users docs](https://microsoft.github.io/CCF/main/governance/open_network.html)
+
+### New user proposal
+```json
+{
+  "actions": [
+    {
+        "name": "set_user",
+        "args": {
+            "cert": "user_cert"
+        }
+    }
+  ]
+}
+```
+
+## Network Governance: Application deployment
+The native format for JavaScript applications in CCF is a [JavaScript application bundle](https://microsoft.github.io/CCF/main/build_apps/js_app_bundle.html), or short app bundle. A bundle can be wrapped directly into a governance proposal for deployment.
+
+### Application deployment proposal
+
+```json
+{
+  "actions": [
+    {
+      "name": "set_js_app",
+      "args": {
+        "bundle": {
+          "metadata": { "endpoints": {} },
+          "modules": []
+        }
+      }
+    }
+  ]
+}
+```
+
+## Network Governance: Open network for users
+Once users are added to the opening network, members should create a proposal to open the network,
+Other members are then able to vote for the proposal using the returned proposal id.
+
+Once the proposal has received enough votes under the rules of the Constitution (ie. ballots which evaluate to true), the network is opened to users. 
+It is only then that users are able to execute transactions on the deployed application.
+
+### Open network proposal
+```json
+{
+  "actions": [
+    {
+        "name": "transition_service_to_open",
+        "args": {
+            "next_service_identity": "service_cert"
+        }
+    }
+  ]
+}
+```
+---
+# Development Dependencies Installation
+
+- CCF Setup
+- NodeJS
+- NPM
+
+## CCF Install
+To install the ccf runtime please check [Install CCF](https://microsoft.github.io/CCF/main/build_apps/install_bin.html)
+
+```bash
+#!/bin/bash
+
+echo "Install CCF" 
+
+echo "Clone CCF Repo to be used in the Prerequisites Installation"
+cd ~/repos
+git clone https://github.com/microsoft/CCF.git
+
+echo "Install CCF Prerequisites"
+cd CCF/getting_started/setup_vm
+./run.sh app-run.yml # Install Prerequisites
+
+echo "Install CCF"
+export CCF_VERSION=$(curl -ILs -o /dev/null -w %{url_effective} https://github.com/microsoft/CCF/releases/latest | sed 's/^.*ccf-//')
+wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_${CCF_VERSION}_amd64.deb
+sudo apt install ./ccf_${CCF_VERSION}_amd64.deb
+
+echo "Verify the installation"
+/opt/ccf/bin/cchost --version
+```
+
+# Code Tour
+
+In VSCode, a [code tour](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour) of the C++ app can be started with: Ctrl + P, `> CodeTour: Start Tour`

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -1,9 +1,11 @@
 # Get Started: Application Development using CCF
 
 ## Overview
+
 Get started repository for building CCF applications using (JavaScript, TypeScript and C++).
 
 ## Quick start
+
 What is CCF: The [Confidential Consortium Framework (CCF)](https://ccf.dev/) is an open-source framework for building a new category of secure, highly available,
 and performant applications that focus on multi-party compute and data.
 
@@ -11,23 +13,28 @@ and performant applications that focus on multi-party compute and data.
 - [Build new CCF applications](https://microsoft.github.io/CCF/main/build_apps/index.html) in TypeScript/JavaScript or C++
 - CCF [Modules API reference](https://microsoft.github.io/CCF/main/js/ccf-app/modules.html)
 - CCF application get started repos
-    -  [CCF application template](https://github.com/microsoft/ccf-app-template)
-    -  [CCF application samples](https://github.com/microsoft/ccf-app-samples)
+  - [CCF application template](https://github.com/microsoft/ccf-app-template)
+  - [CCF application samples](https://github.com/microsoft/ccf-app-samples)
 
 ## Supported Programing Languages
+
 Applications can be written in
+
 - TypeScript
 - JavaScript
 - C++
 - More languages support upcoming on 2023
 
 ## Development environment
-- Development container and VSCode [![Open in VSCode](https://img.shields.io/static/v1?label=Open+in&message=VSCode&logo=visualstudiocode&color=007ACC&logoColor=007ACC&labelColor=2C2C32)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/ccf-app-samples) 
+
+- Development container and VSCode [![Open in VSCode](https://img.shields.io/static/v1?label=Open+in&message=VSCode&logo=visualstudiocode&color=007ACC&logoColor=007ACC&labelColor=2C2C32)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/ccf-app-samples)
 - Github codespace: [![Github codespace](https://img.shields.io/static/v1?label=Open+in&message=GitHub+codespace&logo=github&color=2F363D&logoColor=white&labelColor=2C2C32)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=496290904&machine=basicLinux32gb&devcontainer_path=.devcontainer.json&location=WestEurope)
 - Linux Machine ([Create a VM](https://learn.microsoft.com/en-us/azure/confidential-computing/quick-create-portal) and [Install ccf](https://microsoft.github.io/CCF/main/build_apps/install_bin.html))
 
-## <img src="https://user-images.githubusercontent.com/42961061/191275583-88e00f94-73aa-4d66-9786-047987eb9fa9.png" height=50px> </img>  (JS/Typescript) Applications
+## <img src="https://user-images.githubusercontent.com/42961061/191275583-88e00f94-73aa-4d66-9786-047987eb9fa9.png" height=50px> </img> (JS/Typescript) Applications
+
 To test a ccf application you need go through the following steps:
+
 - Start a CCF Network with at least one node
 - Initialize the CCF network with at least one (active member - user), this is done through [Network Governance Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html).
 - Create an application [deployment proposal](https://microsoft.github.io/CCF/main/build_apps/js_app_bundle.html)
@@ -51,22 +58,27 @@ cd ..
 
 # a dist folder is created with app bundle.
 ```
+
 ---
+
 ### Testing your Application
 
 There are servral ways and tools which helping to test your application
-- Sandbox.sh 
-    - build an initialized a ccf network and deploy your app top it
-    - Support both ccf network types [virtual - release (TEE hardware)]
-    - No governance steps required
 
-- Docker container 
-    - Support both ccf network types [virtual - release (TEE hardware)]
-    - Governance steps required to deploy your app, initialize, and start the network
+- Sandbox.sh
+
+  - build an initialized a ccf network and deploy your app top it
+  - Support both ccf network types [virtual - release (TEE hardware)]
+  - No governance steps required
+
+- Docker container
+
+  - Support both ccf network types [virtual - release (TEE hardware)]
+  - Governance steps required to deploy your app, initialize, and start the network
 
 - Linux Machine
-    - Support both ccf network types [virtual - release (TEE hardware)]
-    - Governance steps required to deploy your app, initialize, and start the network
+  - Support both ccf network types [virtual - release (TEE hardware)]
+  - Governance steps required to deploy your app, initialize, and start the network
 
 #### Testing: Using Sandbox.sh
 
@@ -74,6 +86,7 @@ By runing sandbox.sh script, it is automatically starting a CCF network and depl
 all the governance work is done for you.
 
 Start in a CCF Network in Release mode
+
 ```bash
 /opt/ccf/bin/sandbox.sh --js-app-bundle ./js/dist/  --enclave-type release -p /opt/ccf/lib/libjs.enclave.so.signed
 ...
@@ -82,6 +95,7 @@ Start in a CCF Network in Release mode
 ```
 
 Start in a CCF Network in Virtual mode (the default mode for testing)
+
 ```bash
 /opt/ccf/bin/sandbox.sh --js-app-bundle ./js/dist/
 ...
@@ -107,6 +121,7 @@ Start in a CCF Network in Release mode, via docker container based on config fil
 ```
 
 Start in a CCF Network in Virtual mode, based on virtual config file: "./config/cchost_config_virtual_js.json":
+
 ```bash
  docker build -t ccf-app-samples:js-virtual -f docker/ccf_app_js.virtual .
  docker run -d ccf-app-samples:js-virtual
@@ -115,53 +130,55 @@ Start in a CCF Network in Virtual mode, based on virtual config file: "./config/
 ```
 
 ##### CCF Node Configuration file
+
 The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
 
 ##### CCF network initialization
+
 After the container run, a network is started with one (node - member), you need to execute the following governance steps to initialize the network, [check Network governance section](#network-governance)
+
 - Activate the network members (to begin network governance)
 - Add users (using proposal)
 - Deploy the application (using proposal)
 - Open the network for users (using proposal)
 
 #### Testing: Using Linux Machine
+
 To Start a test CCF network on a VM, it requires [CCF to be intalled](https://microsoft.github.io/CCF/main/build_apps/install_bin.html)
 
 Start the CCF network using the cchost in release mode
+
 ```bash
  /opt/ccf/bin/cchost --config ./config/cchost_config_enclave_js.json
 ```
+
 Or virtual mode
+
 ```bash
 /opt/ccf/bin/cchost --config ./config/cchost_config_virtual_js.json
 ```
 
 ##### CCF Node Configuration file
+
 The configuration for each CCF node must be contained in a single JSON configuration file like [cchost_config_enclave_js.json - cchost_config_virtual_js.json], [ CCF node config file documentation](https://microsoft.github.io/CCF/main/operations/configuration.html)
 
 ##### CCF network initialization
+
 Network is started with one (node - member), you need to execute the following governance steps to initialize the network,, [check Network governance section](#network-governance)
+
 - Activate the network members (to start a network governance)
 - Add users (using proposal)
 - Deploy the application (using proposal)
 - Open the network for users (using proposal)
 
-### Testing: Application Endpoints  
+### Testing: Application Endpoints
 
 Now you can send requests to your endpoints, the following sample requests to log application [(ccf-app-template)](https://github.com/microsoft/ccf-app-template/tree/main/js)
 
 In another terminal:
 
-#### Log application
-```bash
- # send log message to be saved
- curl -X POST https://127.0.0.1:8000/app/log?id=1 --cacert ./workspace/sandbox_common/service_cert.pem -H "Content-Type: application/json" --data '{"msg": "hello world"}'
- # retrieve log message
- curl https://127.0.0.1:8000/app/log?id=1 --cacert ./workspace/sandbox_common/service_cert.pem
- # return:> hello world
-```
-
 #### Banking application
+
 ```bash
 echo "Define vars"
 user0_id=$(openssl x509 -in "user0_cert.pem" -noout -fingerprint -sha256 | cut -d "=" -f 2 | sed 's/://g' | awk '{print tolower($0)}')
@@ -192,8 +209,10 @@ echo "Display balance"
 curl https://ccf_service_url/app/balance/$account_type0 -X GET --cacert service_cert.pem --cert user0_cert.pem --key user0_privk.pem
 curl https://ccf_service_url/app/balance/$account_type1 -X GET --cacert service_cert.pem --cert user1_cert.pem --key user1_privk.pem
 ```
+
 ---
-## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=50px></img> C++ Applications 
+
+## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=50px></img> C++ Applications
 
 CCF apps can also be written in C++. This offers better performance than JavaScript apps but requires a compilation step and a restart of the CCF node for deployment.
 
@@ -247,75 +266,84 @@ Or, for the non-SGX (a.k.a. virtual) variant:
 docker build -t ccf-app-template:cpp-virtual -f docker/ccf_app_cpp.virtual .
 docker run ccf-app-template:virtual
 ```
+
 ---
 
-# Network Governance
+## Network Governance
+
 a Consortium of trusted Members [governs the CCF network](https://microsoft.github.io/CCF/main/governance/index.html). members can submit proposals to CCF and these proposals are accepted based on the rules defined in the [Constitution](https://microsoft.github.io/CCF/main/governance/constitution.html).
 Governance changes are submitted to a [network as Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html), and put to a vote from members.
 
-Submit a proposal 
+Submit a proposal
+
 ```bash
 proposal0_out=$(/opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/proposals" --cacert service_cert.pem --signing-key member0_privk.pem --signing-cert member0_cert.pem --data-binary @proposal.json -H "content-type: application/json")
 proposal0_id=$( jq -r  '.proposal_id' <<< "${proposal0_out}" )
 ```
 
 Members vote to accept or reject the proposal
+
 ```bash
 /opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/proposals/$proposal0_id/ballots" --cacert service_cert.pem --signing-key member0_privk.pem --signing-cert member0_cert.pem --data-binary @vote_accept.json -H "content-type: application/json" | jq
 /opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/proposals/$proposal0_id/ballots" --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @vote_accept.json -H "content-type: application/json" | jq
 ```
- 
-## Network Governance: Activating network members 
+
+### Network Governance: Activating network members
 
 By default the CCF network needs at least one member to be started, after the network is started this member must be activated.
 [Adding or activating members](https://microsoft.github.io/CCF/main/governance/adding_member.html)
 
-### Activate member
+#### Activate member
+
 ```bash
 curl "https://ccf_service_url/gov/ack/update_state_digest" -X POST --cacert service_cert.pem --key member0_privk.pem --cert member0_cert.pem --silent | jq > request.json
 cat request.json
 /opt/ccf/bin/scurl.sh "https://ccf_service_url/gov/ack"  --cacert service_cert.pem --signing-key member0_privk.pem --signing-cert member0_cert.pem --header "Content-Type: application/json" --data-binary @request.json
 ```
 
-### New member proposal
+#### New member proposal
+
 ```json
 {
   "actions": [
     {
-        "name": "set_member",
-        "args": {
-            "cert": "member_cert",
-            "encryption_pub_key": "member_encryption_pub_key"
-        }
+      "name": "set_member",
+      "args": {
+        "cert": "member_cert",
+        "encryption_pub_key": "member_encryption_pub_key"
+      }
     }
   ]
 }
 ```
 
-## Network Governance: Adding users 
+### Network Governance: Adding users
+
 Users are directly interact with the application running in CCF. Their public identity should be voted in by members before they are allowed to issue requests.
 
-Once a CCF network is successfully started and an acceptable number of nodes have joined, members should vote to open the network to Users. 
+Once a CCF network is successfully started and an acceptable number of nodes have joined, members should vote to open the network to Users.
 First, the identities of trusted users should be generated,see [Generating Member Keys and Certificates](https://microsoft.github.io/CCF/main/governance/adding_member.html#generating-member-keys-and-certificates) and [Adding Users docs](https://microsoft.github.io/CCF/main/governance/open_network.html)
 
-### New user proposal
+#### New user proposal
+
 ```json
 {
   "actions": [
     {
-        "name": "set_user",
-        "args": {
-            "cert": "user_cert"
-        }
+      "name": "set_user",
+      "args": {
+        "cert": "user_cert"
+      }
     }
   ]
 }
 ```
 
-## Network Governance: Application deployment
+### Network Governance: Application deployment
+
 The native format for JavaScript applications in CCF is a [JavaScript application bundle](https://microsoft.github.io/CCF/main/build_apps/js_app_bundle.html), or short app bundle. A bundle can be wrapped directly into a governance proposal for deployment.
 
-### Application deployment proposal
+#### Application deployment proposal
 
 ```json
 {
@@ -333,40 +361,45 @@ The native format for JavaScript applications in CCF is a [JavaScript applicatio
 }
 ```
 
-## Network Governance: Open network for users
+### Network Governance: Open network for users
+
 Once users are added to the opening network, members should create a proposal to open the network,
 Other members are then able to vote for the proposal using the returned proposal id.
 
-Once the proposal has received enough votes under the rules of the Constitution (ie. ballots which evaluate to true), the network is opened to users. 
+Once the proposal has received enough votes under the rules of the Constitution (ie. ballots which evaluate to true), the network is opened to users.
 It is only then that users are able to execute transactions on the deployed application.
 
-### Open network proposal
+#### Open network proposal
+
 ```json
 {
   "actions": [
     {
-        "name": "transition_service_to_open",
-        "args": {
-            "next_service_identity": "service_cert"
-        }
+      "name": "transition_service_to_open",
+      "args": {
+        "next_service_identity": "service_cert"
+      }
     }
   ]
 }
 ```
+
 ---
-# Development Dependencies Installation
+
+## Development Dependencies Installation
 
 - CCF Setup
 - NodeJS
 - NPM
 
-## CCF Install
+### CCF Install
+
 To install the ccf runtime please check [Install CCF](https://microsoft.github.io/CCF/main/build_apps/install_bin.html)
 
 ```bash
 #!/bin/bash
 
-echo "Install CCF" 
+echo "Install CCF"
 
 echo "Clone CCF Repo to be used in the Prerequisites Installation"
 cd ~/repos
@@ -384,4 +417,3 @@ sudo apt install ./ccf_${CCF_VERSION}_amd64.deb
 echo "Verify the installation"
 /opt/ccf/bin/cchost --version
 ```
-

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -23,11 +23,11 @@ Applications can be written in
 - TypeScript
 - JavaScript
 - C++
-- More languages support upcoming on 2023
+- More languages support upcoming in 2023
 
 ## Development environment
 
-- Development container and VSCode [![Open in VSCode](https://img.shields.io/static/v1?label=Open+in&message=VSCode&logo=visualstudiocode&color=007ACC&logoColor=007ACC&labelColor=2C2C32)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/ccf-app-samples)
+- VS Code Dev Container [![Open in VSCode](https://img.shields.io/static/v1?label=Open+in&message=VSCode&logo=visualstudiocode&color=007ACC&logoColor=007ACC&labelColor=2C2C32)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/ccf-app-samples)
 - Github codespace: [![Github codespace](https://img.shields.io/static/v1?label=Open+in&message=GitHub+codespace&logo=github&color=2F363D&logoColor=white&labelColor=2C2C32)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=496290904&machine=basicLinux32gb&devcontainer_path=.devcontainer.json&location=WestEurope)
 - Linux Machine ([Create a VM](https://learn.microsoft.com/en-us/azure/confidential-computing/quick-create-portal) and [Install ccf](https://microsoft.github.io/CCF/main/build_apps/install_bin.html))
 
@@ -38,7 +38,7 @@ To test a ccf application you need go through the following steps:
 - Start a CCF Network with at least one node
 - Initialize the CCF network with at least one (active member - user), this is done through [Network Governance Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html).
 - Create an application [deployment proposal](https://microsoft.github.io/CCF/main/build_apps/js_app_bundle.html)
-- Submit the app deployment proposal to the network and all members accept it through voting, This is a part of [Network Governance](https://microsoft.github.io/CCF/main/governance/proposals.html).
+- Submit the app deployment proposal to the network and all members accept it through voting. This is a part of [Network Governance](https://microsoft.github.io/CCF/main/governance/proposals.html).
 - Open the CCF network for users
 - Start to test your application endpoints
 
@@ -51,53 +51,52 @@ otherwise you need to manually install.
 In the checkout of this repository:
 
 ```bash
-cd banking-app
-npm install
+# carried out on the dev-container start up
+cd banking-app && npm install
+
 # build and generate the application bundle and deployment proposal
 make build
-ls
-cd ..
 
-# a dist folder is created with app bundle.
+# a dist folder is created with app bundle and deployment proposal.
 ```
 
 ---
 
 ### Testing your Application
 
-There are servral ways and tools which helping to test your application
+There are several approaches to test your application
 
 - [Sandbox.sh](#testing-using-sandboxsh)
 
-  - Build an initialized CCF network and deploy your app on top of it
-  - Support both ccf network types [virtual - release (TEE hardware)]
+  - Build an initialized CCF network and automatically deploy your app on top of it
+  - Support both ccf network types [virtual - enclave (TEE hardware)]
   - No governance steps required
 
 - [Docker container](#testing-using-docker-containers)
 
-  - Support both ccf network types [virtual - release (TEE hardware)]
+  - Support both ccf network types [virtual - enclave (TEE hardware)]
   - Governance steps required to deploy your app, initialize, and start the network
 
 - [Linux Machine](#testing-using-linux-machine)
 
-  - Support both ccf network types [virtual - release (TEE hardware)]
+  - Support both ccf network types [virtual - enclave (TEE hardware)]
   - Governance steps required to deploy your app, initialize, and start the network
 
 - [Azure Managed CCF Service](#testing-using-azure-managed-ccf-serivce-mccf)
 
   - Using Azure MCCF service, will Create [a Managed CCF network](https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986) which is (initialized, contains an active member, and In Open State)
-  - Support only a ccf network in release mode (TEE hardware)
-  - No governance steps required to start up your network, but you need to deploy your app proposal
+  - Support only a ccf network in enclave mode (TEE hardware)
+  - No governance steps required to start up your network, but you need to use governance to propose an application
 
 #### Testing: Using Sandbox.sh
 
 By running sandbox.sh script, it is automatically starts a CCF network and deploys your application on it.
 The app is up and ready to receive calls and all the governance work is done for you.
 
-Start in a CCF Network in Release mode
+Start in a CCF Network in Enclave mode
 
 ```bash
-/opt/ccf/bin/sandbox.sh --js-app-bundle ./js/dist/  --enclave-type release -p /opt/ccf/lib/libjs.enclave.so.signed
+/opt/ccf/bin/sandbox.sh --js-app-bundle ./banking-app/dist/  --enclave-type release -p /opt/ccf/lib/libjs.enclave.so.signed
 ...
 [12:00:00.000] Press Ctrl+C to shutdown the network
 # It is then possible to interact with the service
@@ -106,7 +105,7 @@ Start in a CCF Network in Release mode
 Start in a CCF Network in Virtual mode (the default mode for testing)
 
 ```bash
-/opt/ccf/bin/sandbox.sh --js-app-bundle ./js/dist/
+/opt/ccf/bin/sandbox.sh --js-app-bundle ./banking-app/dist/
 ...
 [12:00:00.000] Press Ctrl+C to shutdown the network
 # It is then possible to interact with the service
@@ -120,7 +119,7 @@ All the governance steps need to be done manually using [proposal submit and vot
 
 ##### Build and run docker container to start a CCF network
 
-Start in a CCF Network in Release mode, via docker container based on config file "./config/cchost_config_enclave_js.json"
+Start in a CCF Network in Enclave mode, via docker container based on config file "./config/cchost_config_enclave_js.json"
 
 ```bash
  docker build -t ccf-app-samples:js-enclave -f docker/ccf_app_js.enclave .
@@ -154,7 +153,7 @@ To start or join new node you need some configs, The configuration for each CCF 
 
 To Start a test CCF network on a VM, it requires [CCF to be intalled](https://microsoft.github.io/CCF/main/build_apps/install_bin.html)
 
-Start the CCF network using the cchost in release mode
+Start the CCF network using the cchost in enclave mode
 
 ```bash
  /opt/ccf/bin/cchost --config ./config/cchost_config_enclave_js.json
@@ -194,101 +193,16 @@ To test you application using MCCF, you can create Azure Managed CCF Serivce on 
 
 ### Testing: Application Endpoints
 
-Now you can send requests to your endpoints, the following sample requests to log application [(ccf-app-template)](https://github.com/microsoft/ccf-app-template/tree/main/js)
+To check samples on how to test your application endpoints, please check these repositories.
 
-In another terminal:
+- [Banking Application](https://github.com/microsoft/ccf-app-samples/tree/main/banking-app)
+- [Template Application](https://github.com/microsoft/ccf-app-template)
 
-#### Banking application
+## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=40px></img> C++ Applications
 
-```bash
-echo "Define vars"
-user0_id=$(openssl x509 -in "user0_cert.pem" -noout -fingerprint -sha256 | cut -d "=" -f 2 | sed 's/://g' | awk '{print tolower($0)}')
-user1_id=$(openssl x509 -in "user1_cert.pem" -noout -fingerprint -sha256 | cut -d "=" -f 2 | sed 's/://g' | awk '{print tolower($0)}')
-account_type0='current_account'
-account_type1='savings_account'
+CCF apps can also be written in C++. This offers better performance than JavaScript apps but requires a compilation step and a restart of the CCF node for deployment. please check [ccf-app-template](https://github.com/microsoft/ccf-app-template) repository.
 
-echo "create accounts"
-curl https://ccf_service_url/app/account/$user0_id/$account_type0 -X PUT --cacert service_cert.pem --cert member0_cert.pem --key member0_privk.pem
-curl https://ccf_service_url/app/account/$user1_id/$account_type1 -X PUT --cacert service_cert.pem --cert member0_cert.pem --key member0_privk.pem
-
-echo "deposit and display balance for account0"
-curl https://ccf_service_url/app/deposit/$user0_id/$account_type0 -X POST --cacert service_cert.pem --cert member0_cert.pem --key member0_privk.pem -H "Content-Type: application/json" --data-binary '{ "value": 100 }'
-curl https://ccf_service_url/app/balance/$account_type0 -X GET --cacert service_cert.pem --cert user0_cert.pem --key user0_privk.pem
-
-echo "deposit and display balance for account1"
-curl https://ccf_service_url/app/deposit/$user1_id/$account_type1 -X POST --cacert service_cert.pem --cert member0_cert.pem --key member0_privk.pem -H "Content-Type: application/json" --data-binary '{ "value": 2000 }'
-curl https://ccf_service_url/app/balance/$account_type1 -X GET --cacert service_cert.pem --cert user1_cert.pem --key user1_privk.pem
-
-echo "Transfer 40 from user0 to user1"
-transfer_transaction_id=$(curl https://ccf_service_url/app/transfer/$account_type0 -X POST -i --cacert service_cert.pem --cert user0_cert.pem --key user0_privk.pem -H "Content-Type: application/json" --data-binary "{ \"value\": 40, \"user_id_to\": \"$user1_id\", \"account_name_to\": \"$account_type1\" }" | grep -i x-ms-ccf-transaction-id | awk '{print $2}' | sed -e 's/\r//g')
-echo "transaction ID of the transfer: $transfer_transaction_id"
-
-echo "Display receipt"
-curl https://ccf_service_url/app/receipt?transaction_id=$transfer_transaction_id --cacert service_cert.pem --key user0_privk.pem --cert user0_cert.pem
-
-echo "Display balance"
-curl https://ccf_service_url/app/balance/$account_type0 -X GET --cacert service_cert.pem --cert user0_cert.pem --key user0_privk.pem
-curl https://ccf_service_url/app/balance/$account_type1 -X GET --cacert service_cert.pem --cert user1_cert.pem --key user1_privk.pem
-```
-
----
-
-## <img src="https://user-images.githubusercontent.com/42961061/191275172-24269bf0-bb9c-402d-8900-2d589582a781.png" height=50px></img> C++ Applications
-
-CCF apps can also be written in C++. This offers better performance than JavaScript apps but requires a compilation step and a restart of the CCF node for deployment.
-
-The C++ sample app is located in the [`cpp/`](cpp/) directory.
-
-### Build C++ app
-
-In the checkout of this repository:
-
-```bash
-cd cpp/
-mkdir build && cd build
-CC="/opt/oe_lvi/clang-10" CXX="/opt/oe_lvi/clang++-10" cmake -GNinja ..
-ninja
-ls
-
-#libccf_app.enclave.so.signed # SGX-enabled application
-#libccf_app.virtual.so # Virtual application (i.e. insecure!)
-```
-
-See [docs](https://microsoft.github.io/CCF/main/build_apps) for complete instructions on how to build a CCF app.
-
-### Testing: Using Sandbox.sh
-
-```bash
-/opt/ccf/bin/sandbox.sh -p ./libccf_app.virtual.so
-...
-[12:00:00.000] Press Ctrl+C to shutdown the network
-# It is then possible to interact with the service
-```
-
-Or, for an SGX-enabled application (unavailable in development container): `$ /opt/ccf/bin/sandbox.sh -p ./libccf_app.enclave.so.signed -e release`
-
-### Testing: Using docker containers
-
-It is possible to build a runtime image of the C++ application via docker:
-
-```bash
-docker build -t ccf-app-template:cpp-enclave -f docker/ccf_app_cpp.enclave .
-docker run --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx ccf-app-template:cpp-enclave
-...
-2022-01-01T12:00:00.000000Z -0.000 0   [info ] ../src/node/node_state.h:1790        | Network TLS connections now accepted
-# It is then possible to interact with the service
-```
-
-Or, for the non-SGX (a.k.a. virtual) variant:
-
-```bash
-docker build -t ccf-app-template:cpp-virtual -f docker/ccf_app_cpp.virtual .
-docker run ccf-app-template:virtual
-```
-
----
-
-## Network Governance
+## <img src="https://microsoft.github.io/CCF/release/3.x/_static/ccf.svg" height=40px></img> Network Governance
 
 a Consortium of trusted Members [governs the CCF network](https://microsoft.github.io/CCF/main/governance/index.html). members can submit proposals to CCF and these proposals are accepted based on the rules defined in the [Constitution](https://microsoft.github.io/CCF/main/governance/constitution.html).
 Governance changes are submitted to a [network as Proposals](https://microsoft.github.io/CCF/main/governance/proposals.html), and put to a vote from members.
@@ -411,32 +325,5 @@ It is only then that users are able to execute transactions on the deployed appl
 
 ## Development Dependencies Installation
 
-- CCF Setup
-- NodeJS
-- NPM
-
-### CCF Install
-
-To install the ccf runtime please check [Install CCF](https://microsoft.github.io/CCF/main/build_apps/install_bin.html)
-
-```bash
-#!/bin/bash
-
-echo "Install CCF"
-
-echo "Clone CCF Repo to be used in the Prerequisites Installation"
-cd ~/repos
-git clone https://github.com/microsoft/CCF.git
-
-echo "Install CCF Prerequisites"
-cd CCF/getting_started/setup_vm
-./run.sh app-run.yml # Install Prerequisites
-
-echo "Install CCF"
-export CCF_VERSION=$(curl -ILs -o /dev/null -w %{url_effective} https://github.com/microsoft/CCF/releases/latest | sed 's/^.*ccf-//')
-wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_${CCF_VERSION}_amd64.deb
-sudo apt install ./ccf_${CCF_VERSION}_amd64.deb
-
-echo "Verify the installation"
-/opt/ccf/bin/cchost --version
-```
+- [CCF Setup](https://microsoft.github.io/CCF/main/build_apps/install_bin.html)
+- [NodeJS & NPM](https://nodejs.org/en/download/package-manager/)


### PR DESCRIPTION
Adding new GET_STARTED.MD doc to help developers to quickly get started CCF application development using ccf-samples repo and listing the different ways available to test their applications.

Resolve: #38 
