### PR TITLE
Test Data Reconciliation in mCCF

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,16 @@ jobs:
           template: ./deploy/arm/mccf.json
           parameters: ./deploy/arm/parameters.json mccfMemberBasedSecurityPrincipals="[{\"cert\":\"${{ secrets.PUBLIC_CERT }}\", \"encryptionKey\":\"\"}]" resourceName="${{ env.ccfName }}"
 
+      - name: Deploy Data Reconciliation Sample to mCCF
+        uses: devcontainers/ci@v0.2
+        with:
+          runCmd: |
+            cd data-reconciliation-app && make test-mccf
+          env: |
+            PUBLIC_CERT=${{ secrets.PUBLIC_CERT }}
+            PRIVATE_CERT=${{ secrets.PRIVATE_CERT }}
+            CCF_NAME=${{ env.ccfName }}
+
       - name: Deploy Banking Sample to mCCF
         uses: devcontainers/ci@v0.2
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-config/
-docker/

--- a/data-reconciliation-app/Makefile
+++ b/data-reconciliation-app/Makefile
@@ -22,6 +22,13 @@ test-docker-enclave: build-enclave ## 🧪 Test the Data Reconciliation Applicat
 	@echo -e "\e[34m$@\e[0m" || true
 	@. ../scripts/test_docker.sh --enclave --serverIP 172.17.0.4 --port 8080
 
+test-mccf: build ## 🧪 Test the Data Reconciliation Application in a Managed CCF environment
+	@echo -e "\e[34m$@\e[0m" || true
+	$(call check_defined, CCF_NAME)
+	$(call check_defined, PUBLIC_CERT)
+	$(call check_defined, PRIVATE_CERT)
+	@. ../scripts/test_mccf.sh --address "${CCF_NAME}.confidential-ledger.azure.com" --signing-cert "${PUBLIC_CERT}" --signing-key "${PRIVATE_CERT}"
+
 # Start hosting the application using `sandbox.sh` 
 start-host: build ## 🏃 Start the CCF network using Sandbox.sh
 	@echo -e "\e[34m$@\e[0m" || true

--- a/data-reconciliation-app/src/app.json
+++ b/data-reconciliation-app/src/app.json
@@ -1,6 +1,6 @@
 {
   "endpoints": {
-    "/log": {
+    "/votes": {
       "get": {
         "js_module": "endpoints/sample.js",
         "js_function": "read",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -54,8 +54,8 @@ The following commands assume you have created some pem files.
 
 ```bash
 export CCF_NAME=myccf
-export PUBLIC_CERT=$(cat member0_cert.pem)
-export PRIVATE_KEY=$(cat member0_privk.pem)
+export PUBLIC_CERT=$(< member0_cert.pem sed '$!G' | paste -sd '\\n' -)
+export PRIVATE_CERT=$(< member0_privk.pem sed '$!G' | paste -sd '\\n' -)
 
 cd <sample_path>
 make test-mccf


### PR DESCRIPTION
Closes #66
- Deploy the Data Reconciliation to managed CCF
- Fix the Deploy readme so you can deploy manually to mCCF
- Remove the prettierConfig as those folders don't exist anymore