### PR TITLE
Ingest ADR clean up 

### DIFF
--- a/data-reconciliation-app/docs/adr/01-data-ingest.md
+++ b/data-reconciliation-app/docs/adr/01-data-ingest.md
@@ -23,7 +23,7 @@ Gathered requirements:
 ### Endpoint
 
 - Description
-  - Ingest data into our application and add data to K-V store
+  - Ingest member or user data into our application and add data to K-V store
 - Path
   - /ingest
 - HTTP Method
@@ -79,7 +79,7 @@ export interface DataRecordProps {
 
 Our repository will be a K-V store and defined by the `ReconciledRecord` model. A `ReconciledRecord` represents all of the `DataRecords` across the network and each member/users' opinion of the record.
 
-The `ReconciledRecord` key will be the unique id for the data record and the `ReconciliationMap` will be a map of each member/users' and their opinion of the record.
+The `ReconciledRecord` key will be the unique id for the data record and the `ReconciliationMap` will be a map of each member/user ID and their opinion of the record.
 
 ```
 export type ReconciliationMap = Object;
@@ -107,7 +107,7 @@ For example,
 }
 ```
 
-Depending if the unqiue id (key) exists, a `ReconciledRecord`can be `updated` or `created` new via ingest.
+Depending if the key exists, a `ReconciledRecord` can be `updated` or `created` new via ingest.
 
 ## Service
 
@@ -140,12 +140,12 @@ Reference: https://microsoft.github.io/CCF/main/build_apps/kv/api.html#_CPPv4N2k
 
 ## Consequences
 
-The consequences outlined below may be areas of improvement for our application.
+The consequences outlined below may be future areas of improvement for our application.
 
-1. This ingest design does not store the originally ingested data by each member. Rather, the ingest api has the responsibility of storing a `ReconciledRecord`. This may cause a number of issues:
+1. This design does not allow flexibility for schema definition. Reference [adr](./02-data-schema-strategy.md#option3-defining-data-schema-via-deployment)
+2. This design does not store the originally ingested data by each member. Rather, the ingest api has the responsibility of storing a `ReconciledRecord`. This may cause a number of issues:
    - There is no way to audit and members/users cannot see the original data they ingested. Is this a concern?
    - By only storing the `ReconciledRecord`, we make updating or removal of a key for a particular member harder. Is the data immutable?
    - When we create a report on the reconciled data, members/users will only receive a report on the keys they submitted. By using the `ReconciledRecord`, we will have to check the values for each key.
-2. This design does not allow flexibility for schema definition. Reference [adr](./02-data-schema-strategy.md#option3-defining-data-schema-via-deployment)
 
-We need to talk to our Product Owner to determine whether or not data ingested is immutable or if auditing is a concern. We also need to test how expensive creating a report is based on our `ReconciledRecord` model.
+We need to talk to our Product Owner to determine if the data ingested is immutable and/or if auditing is a concern. We also need to see how expensive creating a report is given our `ReconciledRecord` model.

--- a/data-reconciliation-app/docs/adr/01-data-ingest.md
+++ b/data-reconciliation-app/docs/adr/01-data-ingest.md
@@ -2,72 +2,104 @@
 
 ## Status
 
-Proposed
+Approved
 
 ## Context
 
-We need to build an API that ingests member data into our system. Once ingested, we also need to store this data in the K-V store.
+We need to build an API that ingests data into our system. Once ingested, we also need to store this data in the K-V store so we can reconcile and report out on the data.
 
 Gathered requirements:
 
-- Members will decide upon a csv schema ahead of data ingest
-- Members will upload their data via csv, with headers
-  - csv will have 2 columns:
-    - one unique identifier (string)
-    - one attribute associated with the unique identifier (string)
+- Members of the network will decide on a data schema ahead of ingest.
+- Members and Users of the network can ingest data via the API. Data will be ingested via JSON which will include:
+  - one unique identifier (string)
+  - one attribute associated with the unique identifier (string)
 - There is likely going to be a UI on top of our ingest API...so we will treat our app like a backend system. Therefore, we will accept JSON into our ingest API.
 
 ## Decision
 
-## Model for K-V store
+## API
+
+### Endpoint
+
+- Description
+  - Ingest data into our application and add data to K-V store
+- Path
+  - /ingest
+- HTTP Method
+  - POST
+- URL Params
+  - N/A
+- Headers
+  - content-type: application/json
+- Request will be a `ccfapp.Request Object`. We will interrogate the `ccfapp.Request Object` to extract the user or member and [authenticate them via certficates](#security). We will read the request body as a JSON.
+- API Status Codes
+  - OK
+    - Status: 200
+    - Status Text: "Votes have been successfully recorded"
+  - UNAUTHORIZED
+    - Status: 401
+    - Status Text: "Unauthorized"
+  - BAD_REQUEST
+    - Status: 400
+    - Status Text: "Validation Error"
+
+### Security
+
+Users will be authenticated via certificates, which is natively supported by the CCF framework.
+
+//TODO Add reference to this future ADR: https://github.com/microsoft/ccf-app-samples/issues/102
+
+## Models
+
+### Data Schema Model
+
+The ingest model has been documented by [this ADR](./02-data-schema-strategy.md#option3-defining-data-schema-via-deployment). Our ingest data model will look like:
 
 ```
-//psuedo code for model based off forum app
-
-// this is unique for each user
-type User = string;
-
-interface AttributeBase {
-  votes: Record<User, T>;
+export interface DataSchema {
+    key: string;
+    value: string | number;
 }
-
-interface StringAttribute extends AttributeBase<string> {
-  type: "string";
-}
-
-interface NumericAttribute extends AttributeBase<number> {
-  type: "number";
-}
-
-type Attribute = StringAttribute | NumericAttribute;
-
-type AttributeMap = ccfapp.TypedKvMap<string, Attribute>;
 ```
 
-### Sample Ingest Data
+### Data Record Model
 
-For example, from Member 1:
+Upon ingest, `DataSchema` records will be mapped to a `DataRecord` model. `DataRecord`s can be string or numeric.
 
-| id    | company_name |
-| ----- | ------------ |
-| A0128 | microsoft    |
-| A0129 | google       |
-| A0130 | amazon       |
+```
+export type DataAttributeType = string | number;
+export interface DataRecordProps {
+  key: string;
+  value: DataAttributeType;
+}
+```
 
-For example, from Member 2:
-| id | company_name |
-|---|---|
-| A0128 | microsoft |
-|A0129 | alphabet |
-| A0130 | amazon |
+### Repository Model
 
-### Domain Model Sample - String Attribute
+Our repository will be a K-V store and defined by the `ReconciledRecord` model. A `ReconciledRecord` represents all of the `DataRecords` across the network and each member/users' opinion of the record.
+
+The `ReconciledRecord` key will be the unique id for the data record and the `ReconciliationMap` will be a map of each member/users' and their opinion of the record.
+
+```
+export type ReconciliationMap = Object;
+
+export interface ReconciledRecordProps {
+  key: string;
+  values: ReconciliationMap;
+}
+
+export class ReconciledRecord implements ReconciledRecordProps {
+  key: string;
+  values: ReconciliationMap = {};
+```
+
+For example,
 
 ```json
 {
-  "Key": "A0129",
-  "Attribute": {
-    "votes": {
+  "key": "A0129",
+  "value": {
       "Member 1": "google",
       "Member 2": "alphabet"
     }
@@ -75,53 +107,45 @@ For example, from Member 2:
 }
 ```
 
-### API Endpoint
+Depending if the unqiue id (key) exists, a `ReconciledRecord`can be `updated` or `created` new via ingest.
 
-- Description
-  - Adds member data into K-V store, enabling each member to vote on records
-- Path
-  - /votes
-- HTTP Method
-  - POST
-- URL Params
-  - N/A
-- Headers
-  - content-type: application/json
-  - x-api-key: {UUID}
-- Request will be a ccfapp.Request Object, which contains:
-  - user = <User>request.caller
-  - csv = request.body.text()
-- HTTP Status Codes
-  - OK
-    - Status: 200
-    - Status Text: "Votes have been successfully recorded"
-  - Unauthorized
-    - Status: 401
-    - Status Text: "Unauthorized"
-  - Validation Error
-    - Status: 400
-    - Status Text: "Incorrect format"
+## Service
 
-### Service
+### Ingest Service
+
+The ingest service will `update` or `create` a `ReconciledRecord` from `DataRecord`s before saving to the K-V store.
 
 ```
-submitVotes(userId: string, csv: string)
+submitData(userId: string, dataRecords: DataRecord[])
 ```
 
 - Service will leverage repository layer defined below
-- Service will contain business logic: - Check if key already exists via repository `read` - if so, update model & repository `insert` - else, create new model & repository `insert`
+- Service will contain business logic:
+  - Check if key already exists via repository `get`
+    - if it exists, `update` the `reconciled-record` & repository `set`
+    - else, `create` new `reconciled-record` & repository `set`
 
-### Repository
+## Repository
 
-Leverage ccf framework to read and write from kv::Map objects.
+### K-V Repository
 
-- `insert`
-  - Creates new record in AttributeMap
-- `read`
-  - Given key, retrieves record from AttributeMap
+We will leverage the ccf framework to read and write from kv::Map objects.
+
+- `set`
+  - Creates new record
+- `get`
+  - Given key, retrieves record
 
 Reference: https://microsoft.github.io/CCF/main/build_apps/kv/api.html#_CPPv4N2kv18WriteableMapHandle3putERK1KRK1V
 
 ## Consequences
 
-It is only in scope to handle data with one attribute. It is possible in the future, the app may handle muliple attributes of string or numeric types. If that becomes a requirement in the future, we should update the model and complete another ADR.
+The consequences outlined below may be areas of improvement for our application.
+
+1. This ingest design does not store the originally ingested data by each member. Rather, the ingest api has the responsibility of storing a `ReconciledRecord`. This may cause a number of issues:
+   - There is no way to audit and members/users cannot see the original data they ingested. Is this a concern?
+   - By only storing the `ReconciledRecord`, we make updating or removal of a key for a particular member harder. Is the data immutable?
+   - When we create a report on the reconciled data, members/users will only receive a report on the keys they submitted. By using the `ReconciledRecord`, we will have to check the values for each key.
+2. This design does not allow flexibility for schema definition. Reference [adr](./02-data-schema-strategy.md#option3-defining-data-schema-via-deployment)
+
+We need to talk to our Product Owner to determine whether or not data ingested is immutable or if auditing is a concern. We also need to test how expensive creating a report is based on our `ReconciledRecord` model.

--- a/data-reconciliation-app/docs/adr/01-data-ingest.md
+++ b/data-reconciliation-app/docs/adr/01-data-ingest.md
@@ -77,24 +77,25 @@ export interface DataRecordProps {
 
 ### Repository Model
 
-Our repository will be a K-V store and defined by the `ReconciledRecord` model. A `ReconciledRecord` represents all of the `DataRecords` across the network and each member/users' opinion of the record.
-
-The `ReconciledRecord` key will be the unique id for the data record and the `ReconciliationMap` will be a map of each member/user ID and their opinion of the record.
+Our repository will be a K-V store. Our K-V store will be defined as:
 
 ```
-export type ReconciliationMap = Object;
+const kvStore = ccfapp.typedKv(
+  "data",
+  ccfapp.string,
+  ccfapp.json<ReconciledRecord>()
+);
+```
 
-export interface ReconciledRecordProps {
-  key: string;
-  values: ReconciliationMap;
-}
+A `ReconciledRecord` represents all of users who submittted data on the record and their opinion of the record.
 
+```
 export class ReconciledRecord implements ReconciledRecordProps {
   key: string;
   values: ReconciliationMap = {};
 ```
 
-For example,
+The `ReconciliationMap` is a map where key is the user ID and value is the record submitted by the user. For example,
 
 ```json
 {

--- a/data-reconciliation-app/docs/adr/01-data-ingest.md
+++ b/data-reconciliation-app/docs/adr/01-data-ingest.md
@@ -100,9 +100,8 @@ For example,
 {
   "key": "A0129",
   "value": {
-      "Member 1": "google",
-      "Member 2": "alphabet"
-    }
+    "Member 1": "google",
+    "Member 2": "alphabet"
   }
 }
 ```

--- a/data-reconciliation-app/docs/adr/01-data-ingest.md
+++ b/data-reconciliation-app/docs/adr/01-data-ingest.md
@@ -36,7 +36,7 @@ Gathered requirements:
 - API Status Codes
   - OK
     - Status: 200
-    - Status Text: "Votes have been successfully recorded"
+    - Status Text: "Data has been ingested"
   - UNAUTHORIZED
     - Status: 401
     - Status Text: "Unauthorized"

--- a/data-reconciliation-app/docs/adr/02-data-schema-strategy.md
+++ b/data-reconciliation-app/docs/adr/02-data-schema-strategy.md
@@ -81,8 +81,8 @@ Data schema definition at the API could become:
 
 ```typescript
 export interface DataSchema {
-    key: string;
-    value: string | number;
+  key: string;
+  value: string | number;
 }
 ```
 
@@ -109,12 +109,11 @@ While this option provides limited flexibility for members, it introduces maximu
 
 This the summary of alternatives by their complexity and flexibility.
 
-| Options   | Flexibility | Data Reset on Schema Changes | Integration Changes on Schema Changes | Implementation Complexity |
-| ---------:| -----------:| ----------------------------:| -------------------------------------:| -------------------------:|
-| Option 1  | Maximum     |  ✓                           |  ✓                                    | Hard                      |
-| Option 2  | Moderate    |  ✓                           |  ✓                                    | Medium                    |
-| Option 3  | Minimum     |  ✓                           |  ✓                                    | Easy                      |
-
+|  Options | Flexibility | Data Reset on Schema Changes | Integration Changes on Schema Changes | Implementation Complexity |
+| -------: | ----------: | ---------------------------: | ------------------------------------: | ------------------------: |
+| Option 1 |     Maximum |                            ✓ |                                     ✓ |                      Hard |
+| Option 2 |    Moderate |                            ✓ |                                     ✓ |                    Medium |
+| Option 3 |     Minimum |                            ✓ |                                     ✓ |                      Easy |
 
 Considering project timelines from implementation complexity angle, **we have decided to implement Option 3 in this application.**
 

--- a/data-reconciliation-app/docs/data-schema-data-flow.md
+++ b/data-reconciliation-app/docs/data-schema-data-flow.md
@@ -4,9 +4,9 @@ Goal: Investigate data reconciliation sample app data flow, how we will reconcil
 
 ## Generic Data Reconcilition App = Many Use Cases
 
-We will build our application for use across any data schemas. Pending legal approvals, reference data may be a test case for our app.
-
 Main idea: We build a generalized sample app for a bunch of institutions who want to collaborate on some set of data, and share results out on that data.
+
+There is likely going to be a UI on top of our ingest API...so we will treat our app like a backend system. Therefore, ingest and reporting APIs will use JSON.
 
 ## Data Input Schema
 
@@ -23,8 +23,6 @@ Requirements:
   | A003      | XZ          |
 
 - TODO: Product Owner to provide initial sample data set
-- Stretch: Attribute types can be numerical as well.
-- Stretch: Multiple attributes per unique id
 
 ## Data Schema Validation
 
@@ -35,10 +33,10 @@ Our main audience for our sample app is developers. A developer could take our s
 
 ## Data Ingest
 
-- API Endpoint
+- API Endpoints
   - Send single record
   - Send batch of records
-- Data sent via CSV file
+- Data sent via JSON
 
 ## Data Reconiliation
 
@@ -49,10 +47,10 @@ Our main audience for our sample app is developers. A developer could take our s
 
 ## Data Reporting
 
-- API Endpoint: Members will query for results
-  - Query by specific record (unique_id)
-  - Query for all data
-- In order for our app to provide a report on the data, a certain percentage of members need to have "voted" (or submited data) on a particular record. A `voting_threshold` may change based on the scenario and number of members. Therefore, we will make the `voting_threshold` configurable.
+- API Endpoint: Each members will query for their reconciled data. We can only report out on data ingested by the member. Members/users can query by:
+  - key on a specific record
+  - all data
+- In order for our app to provide a report on the data, a certain percentage of members need to have submited data on a particular record. A `voting_threshold` may change based on the scenario and number of members. - `voting_threshold` must be configurable
 - For example, if `voting_threshold`=0.8,
   - Consortium of 5 members -> 4/5 members have to vote
   - Consortium of 3 members -> 2/3 members have to vote
@@ -62,14 +60,13 @@ Our main audience for our sample app is developers. A developer could take our s
 
 - MVP:
 
-  - Results data is categorial - input data attribute value is a string, so status of attribute relative to network will be `in_consensus`, `lack_of_consensus`, or `not_enough_votes`.
-  - Results data will be returned as JSON to each members.
-  - Based on the member, table will look like:
+  - Each record has a `group_status`. Based on reconciliation logic, this status will be `in_consensus`, `lack_of_consensus`, or `not_enough_votes`.
+  - Results data is by each member, and we can only report on the data (keys) submitted by that specific member.
+  - Based on the member, a report table would look like:
 
     | unique_id | attribute_n                 | group_status                                                                                            | count_of_unique_values                               | members_in_agreement                                              | majority_minority                                                                     |
     | --------- | --------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
     | key       | attribute value you inputed | With respect to group, is my attribute value `in_consensus`, `lack_of_consensus`, or `not_enough_votes` | number of different atribute values inputed by group | number of members who agree with the attribute value you provided | are you in the majority or minority with the value provided? (`majority`, `minority`) |
 
-- Stretch: Results data is a numerical summary
-  - For example, instead of `my_status` being categorical, we would return the mean, std based on attribute value being numerical
-  - This is not in scope...if it becomes in scope, we would need to define a table similar to the above
+  - We will not return an actual table or CSV. Rather, all of the data points above will be represented in JSON and returned via the reporting APIs.
+  - The Product Owner specifically chose the column names above, so we must ensure similar language is represented in the returned JSON.

--- a/data-reconciliation-app/docs/data-schema-data-flow.md
+++ b/data-reconciliation-app/docs/data-schema-data-flow.md
@@ -50,7 +50,8 @@ Our main audience for our sample app is developers. A developer could take our s
 - API Endpoint: Each members will query for their reconciled data. We can only report out on data ingested by the member. Members/users can query by:
   - key on a specific record
   - all data
-- In order for our app to provide a report on the data, a certain percentage of members need to have submited data on a particular record. A `voting_threshold` may change based on the scenario and number of members. - `voting_threshold` must be configurable
+- In order for our app to provide a report on the data, a certain percentage of members need to have submited data on a particular record. A `voting_threshold` may change based on the scenario and number of members.
+- `voting_threshold` should be configurable
 - For example, if `voting_threshold`=0.8,
   - Consortium of 5 members -> 4/5 members have to vote
   - Consortium of 3 members -> 2/3 members have to vote


### PR DESCRIPTION
Cleaned up the ingest ADR to accurately reflect the current state of our application.
1. Removed csv lanugage
2. Member AND User language
3. Fixed models
4. Updated consequences/areas of improvement that we have chatted about this week. 

I also cleaned up the initial requirements in data flow. @macromania  @julioalex-rezende  hope it makes designing the reporting apis a bit more clear. 