### PR TITLE
Cleaning up setup-governance and sandbox commands

### DIFF
--- a/data-reconciliation-app/Makefile
+++ b/data-reconciliation-app/Makefile
@@ -32,7 +32,7 @@ test-mccf: build ## 🧪 Test the Data Reconciliation Application in a Managed C
 # Start hosting the application using `sandbox.sh` 
 start-host: build ## 🏃 Start the CCF network using Sandbox.sh
 	@echo -e "\e[34m$@\e[0m" || true
-	@/opt/ccf_virtual/bin/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 2 --constitution-dir ./governance/constitution
+	@/opt/ccf_virtual/bin/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 0 --constitution-dir ./governance/constitution
 
 clean: ## 🧹 Clean the working folders created during build/demo
 	@rm -rf .venv_ccf_sandbox

--- a/scripts/test_sandbox.sh
+++ b/scripts/test_sandbox.sh
@@ -61,7 +61,7 @@ if [ ! -d "$constitution_dir" ]; then
 fi
 
 echo "▶️ Starting sandbox..."
-/opt/ccf_virtual/bin/sandbox.sh --js-app-bundle "$app_dir/dist/" --initial-member-count 3 --initial-user-count 2 --constitution-dir "$constitution_dir" > /dev/null 2>&1 &
+/opt/ccf_virtual/bin/sandbox.sh --js-app-bundle "$app_dir/dist/" --initial-member-count 3 --initial-user-count 0 --constitution-dir "$constitution_dir" > /dev/null 2>&1 &
 sandbox_pid=$!
 echo "💤 Waiting for sandbox . . . (${sandbox_pid})"
 

--- a/scripts/test_sandbox.sh
+++ b/scripts/test_sandbox.sh
@@ -61,7 +61,7 @@ if [ ! -d "$constitution_dir" ]; then
 fi
 
 echo "▶️ Starting sandbox..."
-/opt/ccf_virtual/bin/sandbox.sh --js-app-bundle "$app_dir/dist/" --initial-member-count 3 --initial-user-count 0 --constitution-dir "$constitution_dir" > /dev/null 2>&1 &
+/opt/ccf_virtual/bin/sandbox.sh --js-app-bundle "$app_dir/dist/" --initial-member-count 3 --initial-user-count 2 --constitution-dir "$constitution_dir" > /dev/null 2>&1 &
 sandbox_pid=$!
 echo "💤 Waiting for sandbox . . . (${sandbox_pid})"
 


### PR DESCRIPTION
Code clean-up on data-reconciliation files that manage members & users
The following needed changes were found during the investigation if sandbox environment easily accepts Governance code changes.

- data-recon app does not consider users in its flow: removed
- members were being added but not activated in network (which would affect governance actions): fixed
- sandbox script was being called with users created by default in `start-host` make target: removed

Closes #116 