### PR TITLE
Allowing users to ingest/report data

### DIFF
--- a/data-reconciliation-app/docs/adr/04-Authentication.md
+++ b/data-reconciliation-app/docs/adr/04-Authentication.md
@@ -13,7 +13,7 @@ CCF provides a native support for two common user authentication schemes:
 
 In CCF, Members are capable of performing governance actions, whereas Users can only interact with the application endpoints.
 
-For Data-Reconciliation App, Members can also interact with the application endpoints. For the application perspective, Members and Users have the same roles (both are capable of ingesting/reporting data and there is no distinction between them). For governance actions related to the Data-Reconciliation App (submitting and voting for proposals), again, only members will be able to interact with the governance-specific endpoints.
+In the Data-Reconciliation Application, Members can also interact with the application endpoints. From a application perspective, Members and Users have the same roles (both are capable of ingesting/reporting data and there is no distinction between them). For governance actions related to the Data-Reconciliation App (submitting and voting for proposals), again, only members will be able to interact with the governance-specific endpoints.
 
 
 ## Options

--- a/data-reconciliation-app/docs/adr/04-Authentication.md
+++ b/data-reconciliation-app/docs/adr/04-Authentication.md
@@ -11,7 +11,7 @@ CCF provides a native support for two common user authentication schemes:
 
 ## Roles and Responsibilities
 
-By the way CCF is implemented, Members are capable of perform governance actions, whereas Users can interact only with the application endpoints.
+In CCF, Members are capable of performing governance actions, whereas Users can only interact with the application endpoints.
 
 For Data-Reconciliation App, Members can also interact with the application endpoints. For the application perspective, Members and Users have the same roles (both are capable of ingesting/reporting data and there is no distinction between them). For governance actions related to the Data-Reconciliation App (submitting and voting for proposals), again, only members will be able to interact with the governance-specific endpoints.
 

--- a/data-reconciliation-app/docs/adr/04-Authentication.md
+++ b/data-reconciliation-app/docs/adr/04-Authentication.md
@@ -9,6 +9,13 @@ CCF provides a native support for two common user authentication schemes:
 - JWT Authentication
 - Certificate Authentication
 
+## Roles and Responsibilities
+
+By the way CCF is implemented, Members are capable of perform governance actions, whereas Users can interact only with the application endpoints.
+
+For Data-Reconciliation App, Members can also interact with the application endpoints. For the application perspective, Members and Users have the same roles (both are capable of ingesting/reporting data and there is no distinction between them). For governance actions related to the Data-Reconciliation App (submitting and voting for proposals), again, only members will be able to interact with the governance-specific endpoints.
+
+
 ## Options
 
 ### Option1: Certificate Authentication

--- a/data-reconciliation-app/docs/adr/05-Reporting.md
+++ b/data-reconciliation-app/docs/adr/05-Reporting.md
@@ -6,11 +6,11 @@ Proposed
 
 ## Context
 
-We need to build an API that reports the members' reconciled dataset back to them.
+We need to build an API that reports the members/users' reconciled dataset back to them.
 
 ## Requirements:
 - A report can be requested for a single or for all records.
-- Members will receive a report only for data they have ingested.
+- Members and Users will receive a report only for data they have ingested.
 - A reconciliation report can be requested at anytime, by any member, and the report result will be presented based on the most recent data present in the KV-store for the entire network.
 - Rules for reconciliation are described in [Reconciliation Logic ADR](https://github.com/microsoft/ccf-app-samples/blob/main/data-reconciliation-app/docs/adr/03-reconciliation-logic.md).
 - If a report turns out to be empty, an Error message shall be returned saying that user has no data to be reconciled 
@@ -69,7 +69,7 @@ We need to build an API that reports the members' reconciled dataset back to the
 
 ### Security
 
-Users will be authenticated via certificates, which is natively supported by the CCF framework.
+Users and Members will be authenticated via certificates, which is natively supported by the CCF framework.
 
 //TODO Add reference to this future ADR: https://github.com/microsoft/ccf-app-samples/issues/102
 

--- a/data-reconciliation-app/src/services/authentication-service.ts
+++ b/data-reconciliation-app/src/services/authentication-service.ts
@@ -104,7 +104,7 @@ export class CertBasedAuthenticationService implements IAuthenticationService {
     }
   }
 
-  // Check if call is member or user
+  // Check if caller is an active member or an user registered in the network
   public isValidIdentity(identityId: string): ServiceResult<boolean> {
     if (!identityId) {
       return ServiceResult.Failed({
@@ -115,6 +115,11 @@ export class CertBasedAuthenticationService implements IAuthenticationService {
 
     const isMember = this.isActiveMember(identityId);
     if (isMember.success && isMember.content) {
+      return ServiceResult.Succeeded(true);
+    }
+
+    const isUser = this.isUser(identityId);
+    if (isUser.success && isUser.content) {
       return ServiceResult.Succeeded(true);
     }
 


### PR DESCRIPTION
closes #134 


Including `isUser` verification when validating the identity in Data Reconciliation App, so either members or users will be able to interact with the application