### PR TITLE
Implementing CSV ingestion endpoint

### DIFF
--- a/data-reconciliation-app/docs/adr/01-data-ingest.md
+++ b/data-reconciliation-app/docs/adr/01-data-ingest.md
@@ -15,7 +15,7 @@ Gathered requirements:
   - one unique identifier (string)
   - one attribute associated with the unique identifier (string)
 - There is likely going to be a UI on top of our ingest API...so we will treat our app like a backend system. Therefore, we will accept JSON into our ingest API.
-- As captured in [Ingestion Format ADR](./07-ingestion-format.md), Many financial institutions transmit their data in Comma Seperated Value (CSV) files. Therefore we will also accept CSV for data ingestion, which will then be converted and treated as a JSON object in the application.
+- As captured in [Ingestion Format ADR](./07-ingestion-format.md), many financial institutions transmit their data in Comma Separated Value (CSV) files. Therefore we will also accept CSV for data ingestion.
   - The CSV file data headers must follow the same schema specified for the JSON file
 
 ## Decision
@@ -25,7 +25,7 @@ Gathered requirements:
 ### JSON Ingestion Endpoint
 
 - Description
-  - Ingest member or user data into our application and add data to K-V store via JSON
+  - Ingest member or user data and add to K-V store via JSON
 - Path
   - /ingest
 - HTTP Method
@@ -49,7 +49,7 @@ Gathered requirements:
 ### CSV Ingestion Endpoint
 
 - Description
-  - Ingest member or user data into our application and add data to K-V store via CSV.
+  - Ingest member or user data and add to K-V store via CSV.
   - Data is converted to JSON from the application
 - Path
   - /csv/ingest

--- a/data-reconciliation-app/docs/adr/01-data-ingest.md
+++ b/data-reconciliation-app/docs/adr/01-data-ingest.md
@@ -15,15 +15,17 @@ Gathered requirements:
   - one unique identifier (string)
   - one attribute associated with the unique identifier (string)
 - There is likely going to be a UI on top of our ingest API...so we will treat our app like a backend system. Therefore, we will accept JSON into our ingest API.
+- As captured in [Ingestion Format ADR](./07-ingestion-format.md), Many financial institutions transmit their data in Comma Seperated Value (CSV) files. Therefore we will also accept CSV for data ingestion, which will then be converted and treated as a JSON object in the application.
+  - The CSV file data headers must follow the same schema specified for the JSON file
 
 ## Decision
 
 ## API
 
-### Endpoint
+### JSON Ingestion Endpoint
 
 - Description
-  - Ingest member or user data into our application and add data to K-V store
+  - Ingest member or user data into our application and add data to K-V store via JSON
 - Path
   - /ingest
 - HTTP Method
@@ -33,6 +35,31 @@ Gathered requirements:
 - Headers
   - content-type: application/json
 - Request will be a `ccfapp.Request Object`. We will interrogate the `ccfapp.Request Object` to extract the user or member and [authenticate them via certficates](#security). We will read the request body as a JSON.
+- API Status Codes
+  - OK
+    - Status: 200
+    - Status Text: "Data has been ingested"
+  - UNAUTHORIZED
+    - Status: 401
+    - Status Text: "Unauthorized"
+  - BAD_REQUEST
+    - Status: 400
+    - Status Text: "Validation Error"
+
+### CSV Ingestion Endpoint
+
+- Description
+  - Ingest member or user data into our application and add data to K-V store via CSV.
+  - Data is converted to JSON from the application
+- Path
+  - /csv/ingest
+- HTTP Method
+  - POST
+- URL Params
+  - N/A
+- Headers
+  - content-type: text/csv
+- Request will be a `ccfapp.Request Object`. We will interrogate the `ccfapp.Request Object` to extract the user or member and [authenticate them via certficates](#security). We will read the request body as a text and do the convertion within the code.
 - API Status Codes
   - OK
     - Status: 200
@@ -56,18 +83,29 @@ Users will be authenticated via certificates, which is natively supported by the
 
 The ingest model has been documented by [this ADR](./02-data-schema-strategy.md#option3-defining-data-schema-via-deployment). Our ingest data model will look like:
 
-```
+```typescript
 export interface DataSchema {
     key: string;
     value: string | number;
 }
 ```
 
+### Default Data Schema
+
+The defined default data schema is described below. JSON and CSV files must follow it to be accepted in the application.
+
+```typescript
+const schema: DataSchema = {
+  key: { name: "lei", type: "string" },
+  value: { name: "nace", type: "string" },
+};
+```
+
 ### Data Record Model
 
 Upon ingest, `DataSchema` records will be mapped to a `DataRecord` model. `DataRecord`s can be string or numeric.
 
-```
+```typescript
 export type DataAttributeType = string | number;
 export interface DataRecordProps {
   key: string;
@@ -79,7 +117,7 @@ export interface DataRecordProps {
 
 Our repository will be a K-V store. Our K-V store will be defined as:
 
-```
+```typescript
 const kvStore = ccfapp.typedKv(
   "data",
   ccfapp.string,
@@ -89,7 +127,7 @@ const kvStore = ccfapp.typedKv(
 
 A `ReconciledRecord` represents all of users who submittted data on the record and their opinion of the record.
 
-```
+```typescript
 export class ReconciledRecord implements ReconciledRecordProps {
   key: string;
   values: ReconciliationMap = {};
@@ -115,7 +153,7 @@ Depending if the key exists, a `ReconciledRecord` can be `updated` or `created` 
 
 The ingest service will `update` or `create` a `ReconciledRecord` from `DataRecord`s before saving to the K-V store.
 
-```
+```typescript
 submitData(userId: string, dataRecords: DataRecord[])
 ```
 

--- a/data-reconciliation-app/package.json
+++ b/data-reconciliation-app/package.json
@@ -17,6 +17,7 @@
     "jsrsasign-util": "^1.0.2",
     "jwt-decode": "^3.0.0",
     "lodash-es": "^4.17.15",
+    "papaparse": "5.3.2",
     "protobufjs": "^6.10.1"
   },
   "devDependencies": {
@@ -33,6 +34,7 @@
     "@types/lodash-es": "^4.17.3",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.9",
+    "@types/papaparse": "^5.3.7",
     "babel-jest": "^29.3.1",
     "del-cli": "^3.0.1",
     "http-server": "^0.13.0",

--- a/data-reconciliation-app/src/endpoints/all.ts
+++ b/data-reconciliation-app/src/endpoints/all.ts
@@ -1,2 +1,3 @@
 export * from "./ingest";
+export * from "./ingest-csv";
 export * from "./reporting";

--- a/data-reconciliation-app/src/endpoints/app.json
+++ b/data-reconciliation-app/src/endpoints/app.json
@@ -29,6 +29,35 @@
         }
       }
     },
+    "/csv/ingest": {
+      "post": {
+        "js_module": "endpoints/ingest-csv.js",
+        "js_function": "postHandlerCsv",
+        "forwarding_required": "always",
+        "authn_policies": ["member_cert", "user_cert"],
+        "mode": "readwrite",
+        "openapi": {
+          "responses": {
+            "200": {
+              "description": "Ok",
+              "content": {
+                "application/json": {
+                  "schema": { "type": "object" }
+                }
+              }
+            }
+          },
+          "requestBody": {
+            "required": true,
+            "content": {
+              "text/csv": {
+                "schema": { "type":"object" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/report": {
       "get": {
         "js_module": "endpoints/reporting.js",

--- a/data-reconciliation-app/src/endpoints/ingest-csv.ts
+++ b/data-reconciliation-app/src/endpoints/ingest-csv.ts
@@ -1,0 +1,51 @@
+import * as ccfapp from "@microsoft/ccf-app";
+import papa from "papaparse/papaparse.min.js";
+import { ServiceResult } from "../utils/service-result";
+import { ApiResult, CCFResponse } from "../utils/api-result";
+import { DataSchema } from "../models/data-schema";
+import authenticationService from "../services/authentication-service";
+import ingestService from "../services/ingest-service";
+
+export function postHandlerCsv(
+  request: ccfapp.Request<any>
+): ccfapp.Response<CCFResponse> {
+  // get caller identity
+  const getCallerId = authenticationService.getCallerId(request);
+  if (getCallerId.failure) return ApiResult.Failed(getCallerId);
+  const callerId = getCallerId.content;
+
+  // check if caller has a valid identity
+  const isValidIdentity = authenticationService.isValidIdentity(callerId);
+  if (isValidIdentity.failure || !isValidIdentity.content)
+    return ApiResult.AuthFailure();
+
+  // read CSV data from request body as json
+  let getJsonData = getCsvBodyAsJson(request);
+  if (getJsonData.failure) return ApiResult.Failed(getJsonData);
+  const data = getJsonData.content;
+
+  // map input data-model to data-record model
+  const mapDataRecords = DataSchema.mapDataRecords(data);
+  if (mapDataRecords.failure) return ApiResult.Failed(mapDataRecords);
+
+  // submit data to be save to data-store
+  const response = ingestService.submitData(callerId, mapDataRecords.content);
+  return ApiResult.Succeeded(response);
+}
+
+function getCsvBodyAsJson(request: ccfapp.Request<any>): ServiceResult<any> {
+  try {
+    // parse CSV, converting to json
+    var result = papa.parse(request.body.text(), {header: true, skipEmptyLines: true});
+    return ServiceResult.Succeeded(result.data);
+
+  } catch (ex) {
+    return ServiceResult.Failed({
+      errorMessage: ex.message,
+      errorType: "InvalidCsvToJSON",
+      details: ex,
+    });
+  }
+}
+
+

--- a/data-reconciliation-app/test/data-samples/member0_data.csv
+++ b/data-reconciliation-app/test/data-samples/member0_data.csv
@@ -1,0 +1,11 @@
+lei,nace
+1,test1
+2,test2
+3,test3
+4,test4
+5,test5
+6,test6
+7,test7
+8,test8
+9,test9
+10,test10

--- a/data-reconciliation-app/test/test.sh
+++ b/data-reconciliation-app/test/test.sh
@@ -91,9 +91,10 @@ echo "Test start"
 printf "\n  -------- Test Ingestion Service --------  \n\n"
 
 ingestUrl="$server/app/ingest";
+ingestCsvUrl="$server/app/csv/ingest";
 
 memberName="member0"
-check_eq "$memberName - data ingest should succeed" "200" "$(curl $ingestUrl -X POST $(cert_arg $memberName) -H "Content-Type: application/json" --data-binary "@../../test/data-samples/${memberName}_data.json" $only_status_code)"
+check_eq "$memberName - data ingest through CSV should succeed" "200" "$(curl $ingestCsvUrl -X POST $(cert_arg $memberName) -H "Content-Type: text/csv" --data-binary "@../../test/data-samples/${memberName}_data.csv" $only_status_code)"
 
 memberName="member1"
 check_eq "$memberName - data ingest should succeed" "200" "$(curl $ingestUrl -X POST $(cert_arg $memberName) -H "Content-Type: application/json" --data-binary "@../../test/data-samples/${memberName}_data.json" $only_status_code)"


### PR DESCRIPTION
closes #131 
Implementing CSV Ingestion endpoint.
- `papaparse` added to devDependencies
- new endpoint created: `/app/csc/ingest`
- `ingest-csv.ts` file created to handle CSV endpoint
- `test.sh` script slightly changed so now member0 submits their data through the CSV endpoint.
- some tweaks in the ADR to document CSV ingestion and default schema


CSV is now accepted as input file through `/app/csv/ingest` endpoint
As the focus of this is just a sample, no concerns were taken with respect to performance or data size.

Once in the application, CSV data is read from the http request body as text and converted to JSON using `papaparse`, which handles different validations to the file under the hoods.

Once converted to JSON, the code takes the same flow as if JSON was used directly.


