### PR TITLE
Cache the devcontainer

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Deploy Banking Sample to mCCF
         uses: devcontainers/ci@v0.2
         with:
+          imageName: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
             cd banking-app && make test-mccf
           env: |
@@ -52,6 +53,7 @@ jobs:
       - name: Deploy Data Reconciliation Sample to mCCF
         uses: devcontainers/ci@v0.2
         with:
+          imageName: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
             cd data-reconciliation-app && make test-mccf
           env: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           creds: '{"clientId":"${{ secrets.ARM_CLIENT_ID }}","clientSecret":"${{ secrets.ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.ARM_TENANT_ID }}"}' # editorconfig-checker-disable-line
 
+      - name: Login to GH-CR to push the updated devcontainer image
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Resource Group
         uses: Azure/CLI@v1
         with:
@@ -43,6 +50,7 @@ jobs:
         uses: devcontainers/ci@v0.2
         with:
           imageName: ghcr.io/microsoft/ccf-samples-devcontainer
+          #refFilterForPush: refs/heads/main
           runCmd: |
             cd banking-app && make test-mccf
           env: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,8 +50,9 @@ jobs:
         uses: devcontainers/ci@v0.2
         with:
           imageName: ghcr.io/microsoft/ccf-samples-devcontainer
-          eventFilterForPush: workflow_dispatch
-          #refFilterForPush: refs/heads/main
+          cacheFrom: ghcr.io/microsoft/ccf-samples-devcontainer
+          eventFilterForPush: push
+          refFilterForPush: refs/heads/main
           runCmd: |
             cd banking-app && make test-mccf
           env: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
             #!/bin/bash
             az group create --name ${{ env.ccfName }} --location ${{ env.ResourceGroupLocation }}
 
-      - name: Deploy
+      - name: Deploy Managed CCF Network
         uses: azure/arm-deploy@v1
         with:
           resourceGroupName: ${{ env.ccfName }}
@@ -50,7 +50,8 @@ jobs:
         uses: devcontainers/ci@v0.2
         with:
           imageName: ghcr.io/microsoft/ccf-samples-devcontainer
-          #refFilterForPush: refs/heads/main
+          refFilterForPush: refs/heads/main
+          eventFilterForPush: workflow_dispatch
           runCmd: |
             cd banking-app && make test-mccf
           env: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,8 +50,8 @@ jobs:
         uses: devcontainers/ci@v0.2
         with:
           imageName: ghcr.io/microsoft/ccf-samples-devcontainer
-          refFilterForPush: refs/heads/main
           eventFilterForPush: workflow_dispatch
+          #refFilterForPush: refs/heads/main
           runCmd: |
             cd banking-app && make test-mccf
           env: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,23 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Login to GH-CR to push the updated devcontainer image
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build samples in DevContainer
         uses: devcontainers/ci@v0.2
         with:
+          imageName: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
             git config --global --add safe.directory "$GITHUB_WORKSPACE"
             make lint
             cd banking-app && make test && make test-docker-virtual
+          refFilterForPush: refs/heads/main
           env: |
             GITHUB_WORKSPACE
 
@@ -40,6 +50,7 @@ jobs:
       - name: Build samples in DevContainer
         uses: devcontainers/ci@v0.2
         with:
+          imageName: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
             cd auditable-logging-app && make test
 
@@ -55,5 +66,6 @@ jobs:
       - name: Build samples in DevContainer
         uses: devcontainers/ci@v0.2
         with:
+          imageName: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
             cd data-reconciliation-app && make test && make test-docker-virtual

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Login to GH-CR to push the updated devcontainer image
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build samples in DevContainer
         uses: devcontainers/ci@v0.2
         with:
@@ -34,7 +27,6 @@ jobs:
             git config --global --add safe.directory "$GITHUB_WORKSPACE"
             make lint
             cd banking-app && make test && make test-docker-virtual
-          refFilterForPush: refs/heads/main
           env: |
             GITHUB_WORKSPACE
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build samples in DevContainer
         uses: devcontainers/ci@v0.2
         with:
-          imageName: ghcr.io/microsoft/ccf-samples-devcontainer
+          cacheFrom: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
             git config --global --add safe.directory "$GITHUB_WORKSPACE"
             make lint
@@ -42,7 +42,7 @@ jobs:
       - name: Build samples in DevContainer
         uses: devcontainers/ci@v0.2
         with:
-          imageName: ghcr.io/microsoft/ccf-samples-devcontainer
+          cacheFrom: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
             cd auditable-logging-app && make test
 
@@ -58,6 +58,6 @@ jobs:
       - name: Build samples in DevContainer
         uses: devcontainers/ci@v0.2
         with:
-          imageName: ghcr.io/microsoft/ccf-samples-devcontainer
+          cacheFrom: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
             cd data-reconciliation-app && make test && make test-docker-virtual


### PR DESCRIPTION
When we push to main, push the devcontainer image to GitHub Container Registry

When we build CI, use this container registry as a cache