### PR TITLE
Attempt to get test-docker working across local, CI and codespace

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -16,7 +16,8 @@
         "editor.codeActionsOnSave": {
           "source.fixAll": true
         }
-      }
+      },
+      "appPort": [ 8080 ]
     }
   },
   "postStartCommand": "scripts/devContainer_OnStart.sh",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
         with:
           cacheFrom: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
-            cd data-reconciliation-app && make unit-test && make test
+            cd data-reconciliation-app && make unit-test && make test && test-docker-virtual

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
         with:
           cacheFrom: ghcr.io/microsoft/ccf-samples-devcontainer
           runCmd: |
-            cd data-reconciliation-app && make unit-test && make test && test-docker-virtual
+            cd data-reconciliation-app && make unit-test && make test && make test-docker-virtual

--- a/data-reconciliation-app/governance/nodes/cchost_config_virtual_js.json
+++ b/data-reconciliation-app/governance/nodes/cchost_config_virtual_js.json
@@ -10,9 +10,12 @@
     },
     "rpc_interfaces": {
       "main_interface": {
-        "bind_address": "127.0.0.1:8080"
+        "bind_address": "172.17.0.2:8080"
       }
     }
+  },
+  "node_certificate": {
+    "subject_alt_names": ["iPAddress:127.0.0.1"]
   },
   "command": {
     "type": "Start",

--- a/scripts/test_docker.sh
+++ b/scripts/test_docker.sh
@@ -77,7 +77,7 @@ function finish {
 }
 trap finish EXIT
 
-docker run --rm --detach --net=host "$app_name:$enclave_type"
+docker run --detach --rm -p 8080:8080 "$app_name:$enclave_type"
 containerId=$(docker ps -f ancestor="$app_name:$enclave_type" -q)
 
 echo "💤 Waiting for CCF node to create the certificate..."


### PR DESCRIPTION
Attempt to resolve #95

--ip does not do what a superficial reading of the documentation suggests: the internal interface is always 172.17.0.2, and there is not a corresponding external interface created when it is passed, at least not one that's available for the host to connect to, which is what matters for the test clients.

Instead, -p 8080:8080 is the way to forward traffic through 127.0.0.1 on the host to the container's 172.17.0.2. You could be forgiven for thinking that EXPOSE/8080 in the dockerfile does that, but no, that's only for other containers, not for the host.


So the recipe looks like this:

1. bind to 172.17.0.2
2. Add a SAN for 127.0.0.1, because that's how the client will come in, to get the TLS handshake to work.
3. connect via 127.0.0.1

This work both local and in codespaces, but not in the CI, same as --net=host.