### PR TITLE
Remove automatic deployment to mccf

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,6 @@
 name: "deploy-test-app-samples-to-mccf"
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CCF App Samples CI](https://github.com/microsoft/ccf-app-samples/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/ccf-app-samples/actions/workflows/ci.yml)
 
-Sample applications for the [Confidential Consortium Framework (CCF)](https://ccf.microsoft.com/).
+Sample applications for the [Confidential Consortium Framework (CCF)](https://www.microsoft.com/en-us/research/project/confidential-consortium-framework/).
 
 ## Quickstart
 


### PR DESCRIPTION
Remove the automatic deployment to a Managed CCF in Azure every time main is built. There is no subscription associated with this repo anymore. This is to make the ci of main green (passing) again.

I also noticed the link in the main Readme was broken.